### PR TITLE
[WF-221] CI: Fix GitHub Actions matrix output formatting

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -46,7 +46,7 @@ jobs:
           else
             CHARM_DIRS="charms/${{ inputs.charm-name }}"
           fi
-          MATRIX=$(printf '%s\n' $CHARM_DIRS | jq -R . | jq -s '{include: map({charm_path: .})}')
+          MATRIX=$(printf '%s\n' $CHARM_DIRS | jq -R . | jq -s -c '{include: map({charm_path: .})}')
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   promote:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,7 +59,7 @@ jobs:
                   ;;
               esac
 
-              matrix=$(jq \
+              matrix=$(jq -c \
                 --arg charm_path "$charm_path" \
                 --arg platform "$platform" \
                 --arg runner "$runner" \


### PR DESCRIPTION
## Description
This PR ensures the dynamically generated GitHub Actions matrix is emitted as single-line JSON.

Reason Being, GitHub Actions job outputs require key=value pairs to be written on a single line.
Previously, jq produced pretty-printed (multi-line) JSON, causing the workflow to fail with:

`Error: Invalid format '  "include": ['`

## Proposed Fix
Use `jq -c` when building the matrix so the output is compact and safe to write to `$GITHUB_OUTPUT`.

## Testing
- Verified locally by simulating `$GITHUB_OUTPUT`
- Confirmed matrix is valid JSON and single-line

No functional changes to matrix contents.