### PR TITLE
[WF-221] Updated Docs and updated credentials to secrets.CHARMHUB_TOKEN

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Promote charm
         uses: canonical/charming-actions/release-charm@2.6.2
         with:
-          credentials: ${{ secrets.CHARMHUB_CREDENTIALS }}
+          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ inputs.origin-channel }}
           destination-channel: ${{ inputs.destination-channel }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Promote charm
         uses: canonical/charming-actions/release-charm@2.6.2
         with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          credentials: ${{ secrets.CHARMHUB_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ inputs.origin-channel }}
           destination-channel: ${{ inputs.destination-channel }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Promote charm
         uses: canonical/charming-actions/release-charm@2.6.2
         with:
-          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ inputs.origin-channel }}
           destination-channel: ${{ inputs.destination-channel }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          credentials: ${{ secrets.CHARMHUB_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           charm-path: ${{ matrix.charm_path }}
           channel: 3.1/edge

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
-          credentials: ${{ secrets.CHARMHUB_CREDENTIALS }}
+          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           charm-path: ${{ matrix.charm_path }}
           channel: 3.1/edge

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
-          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           charm-path: ${{ matrix.charm_path }}
           channel: 3.1/edge

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  verify-charmhub-secret:
+    name: Verify Charmhub credentials secret (non-fork PRs only)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    steps:
+      - name: Check secret present and JSON-shaped
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${{ secrets.charmhub_token }}" ]; then
+            echo "charmhub_token secret is NOT set" >&2
+            exit 1
+          fi
+
+          printf '%s' '${{ secrets.charmhub_token }}' | jq -e . >/dev/null
+          echo "charmhub_token is present and valid JSON"
+
   lint:
     runs-on: ubuntu-latest
     strategy:
@@ -69,7 +87,7 @@ jobs:
             echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          MATRIX=$(printf '%s\n' $FILES | jq -R . | jq -s '{include: map({test_file: .})}')
+          MATRIX=$(printf '%s\n' $FILES | jq -R . | jq -s -c '{include: map({test_file: .})}')
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   integration-tests:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,24 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  verify-charmhub-secret:
-    name: Verify Charmhub credentials secret (non-fork PRs only)
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' || !github.event.pull_request.head.repo.fork }}
-    steps:
-      - name: Check secret present and JSON-shaped
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ -z "${{ secrets.CHARMHUB_TOKEN }}" ]; then
-            echo "charmhub_token secret is NOT set" >&2
-            exit 1
-          fi
-          echo '${{ secrets.CHARMHUB_TOKEN }}'
-          printf '%s' '${{ secrets.CHARMHUB_TOKEN }}' | jq -e . >/dev/null
-          echo "charmhub_token is present and valid JSON"
-
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,19 +17,19 @@ jobs:
   verify-charmhub-secret:
     name: Verify Charmhub credentials secret (non-fork PRs only)
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    if: ${{ github.event_name == 'pull_request' || !github.event.pull_request.head.repo.fork }}
     steps:
       - name: Check secret present and JSON-shaped
         shell: bash
         run: |
           set -euo pipefail
 
-          if [ -z "${{ secrets.charmhub_token }}" ]; then
+          if [ -z "${{ secrets.CHARMHUB_TOKEN }}" ]; then
             echo "charmhub_token secret is NOT set" >&2
             exit 1
           fi
 
-          printf '%s' '${{ secrets.charmhub_token }}' | jq -e . >/dev/null
+          printf '%s' '${{ secrets.CHARMHUB_TOKEN }}' | jq -e . >/dev/null
           echo "charmhub_token is present and valid JSON"
 
   lint:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,13 +24,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -z "${secrets.CHARMHUB_TOKEN}" ]; then
-            echo "CHARMHUB_TOKEN secret is NOT set" >&2
+          if [ -z "${{ secrets.CHARMHUB_TOKEN }}" ]; then
+            echo "charmhub_token secret is NOT set" >&2
             exit 1
           fi
-
-          printf '%s' "${secrets.CHARMHUB_TOKEN}" | jq -e . >/dev/null
-          echo "CHARMHUB_TOKEN is present and valid JSON"
+          echo '${{ secrets.CHARMHUB_TOKEN }}'
+          printf '%s' '${{ secrets.CHARMHUB_TOKEN }}' | jq -e . >/dev/null
+          echo "charmhub_token is present and valid JSON"
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,12 +24,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -z "${CHARMHUB_TOKEN}" ]; then
+          if [ -z "${secrets.CHARMHUB_TOKEN}" ]; then
             echo "CHARMHUB_TOKEN secret is NOT set" >&2
             exit 1
           fi
 
-          printf '%s' "${CHARMHUB_TOKEN}" | jq -e . >/dev/null
+          printf '%s' "${secrets.CHARMHUB_TOKEN}" | jq -e . >/dev/null
           echo "CHARMHUB_TOKEN is present and valid JSON"
 
   lint:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,13 +24,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -z "${{ secrets.CHARMHUB_TOKEN }}" ]; then
-            echo "charmhub_token secret is NOT set" >&2
+          if [ -z "${CHARMHUB_TOKEN}" ]; then
+            echo "CHARMHUB_TOKEN secret is NOT set" >&2
             exit 1
           fi
 
-          printf '%s' '${{ secrets.CHARMHUB_TOKEN }}' | jq -e . >/dev/null
-          echo "charmhub_token is present and valid JSON"
+          printf '%s' "${CHARMHUB_TOKEN}" | jq -e . >/dev/null
+          echo "CHARMHUB_TOKEN is present and valid JSON"
 
   lint:
     runs-on: ubuntu-latest

--- a/charms/api-server/README.md
+++ b/charms/api-server/README.md
@@ -1,11 +1,7 @@
 # airflow-api-server
 
-Charmhub package name: airflow-api-server
-More information: https://charmhub.io/airflow-api-server
-
 This charm deploys and manages the Apache Airflow API Server as part of a Charmed Airflow deployment.
-It is designed to work only in coordination with the Airflow Coordinator charm, which centralizes
-configuration, secrets, and cluster-wide validation.
+An API Server exposes the REST API endpoints that allow clients to programmatically interact with Airflow resources such as DAGs, runs, and task metadata.
 
 ## Overview
 
@@ -30,8 +26,6 @@ juju integrate airflow-api-server-k8s airflow-coordinator-k8s
 - The charm transitions to Active once the configuration is written, the Pebble layer is added, and a successful replan occurs.
 
 
-## Other resources
+## OCI Images
 
-- [Contributing](CONTRIBUTING.md)
-
-- See the [Juju documentation](https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/) for more information about developing and improving charms.
+This charm uses the official Airflow OCI image: `ubuntu/airflow`.

--- a/charms/dag-processor/README.md
+++ b/charms/dag-processor/README.md
@@ -1,11 +1,7 @@
 # airflow-dag processor
 
-Charmhub package name: airflow-dag processor
-More information: https://charmhub.io/airflow-dag processor
-
-This charm deploys and manages the Apache Airflow API Server as part of a Charmed Airflow deployment.
-It is designed to work only in coordination with the Airflow Coordinator charm, which centralizes
-configuration, secrets, and cluster-wide validation.
+This charm deploys and manages the Apache Airflow Dag Processor as part of a Charmed Airflow deployment.
+The DAG processor continuously scans the DAGs folder, parses Python files to discover DAG definitions.
 
 ## Overview
 

--- a/charms/scheduler/README.md
+++ b/charms/scheduler/README.md
@@ -1,9 +1,21 @@
 # airflow-scheduler-k8s
 
 A Juju charm for deploying and managing Apache Airflow Scheduler on Kubernetes. The Airflow Scheduler monitors all tasks and DAGs, then triggers task instances following their dependencies.
+
+## Overview
+
+The Airflow Scheduler charm:
+
+- Runs the Airflow `scheduler` service inside a workload container
+- Receives rendered Airflow configuration and secrets from the Airflow Coordinator
+- Participates as one of the Airflow core components alongside:
+  - API Server
+  - Triggerer
+  - DAG Processor
+
 ## Usage
 
-```bash
+```
 juju deploy airflow-scheduler-k8s
 juju deploy airflow-coordinator-k8s
 juju integrate airflow-scheduler-k8s airflow-coordinator-k8s
@@ -13,4 +25,4 @@ The scheduler will enter a blocked state until all required Airflow core compone
 
 ## OCI Images
 
-This charm uses the official Airflow OCI image: `ubuntu/airflow`
+This charm uses the official Airflow OCI image: `ubuntu/airflow`.

--- a/charms/triggerer/README.md
+++ b/charms/triggerer/README.md
@@ -1,11 +1,7 @@
 # airflow-triggerer
 
-Charmhub package name: airflow-triggerer-k8s
-More information: https://charmhub.io/airflow-triggerer
-
 This charm deploys and manages the Apache Airflow Triggerer as part of a Charmed Airflow deployment.
-It is designed to work only in coordination with the Airflow Coordinator charm, which centralizes
-configuration, secrets, and cluster-wide validation.
+The Triggerer runs an asynchronous event loop that executes trigger code and fires events back to the scheduler when conditions are met. This enables deferrable operators to free up worker resources while waiting.
 
 ## Overview
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Updated README.md for charms to have a consistent description.

Update the charm publishing workflow to use the existing secrets.charmhub_token for authentication when uploading charms to Charmhub.
- Switched the charm publishing step to reference secrets.charmhub_token
- No changes to charm publishing logic or behavior
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
