### PR TITLE
[WF-281] Adding Terraform modules for airflow core charms

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,22 @@
+name: Terraform checks
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  pull-request-terraform-checks:
+    name: PR Terraform checks
+    strategy:
+      matrix:
+        module-directory:
+          - charms/api-server/terraform
+          - charms/dag-processor/terraform
+          - charms/scheduler/terraform
+          - charms/triggerer/terraform
+    uses: canonical/workflows-team/.github/workflows/terraform.yaml@main
+    with:
+      module-directory: ${{ matrix.module-directory }}

--- a/charms/api-server/terraform/README.md
+++ b/charms/api-server/terraform/README.md
@@ -1,9 +1,11 @@
 # Terraform module for Airflow API Server
 
-This is a Terraform module facilitating the deployment of the Airflow API Server charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+This module deploys the Airflow API Server charm using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For provider details, see the [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
 ## Requirements
-This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+- Terraform >= 1.12.2
+- Provider: `juju` >= 1.0.0
+- A Juju model must exist (see [Usage](#usage))
 
 ## API
 
@@ -12,26 +14,26 @@ The module offers the following configurable inputs:
 
 | Name | Type | Description | Required |
 | - | - | - | - |
-| `app_name`| string | Application name | False |
+| `app_name` | string | Name of the deployed application | False |
 | `units` | number | Number of units to deploy | False |
-| `model_uuid`| string | UUID of the model that the charm is deployed on | True |
-| `revision`| number | Revision number of the charm name | False |
-| `channel`| string | Channel that the charm is deployed from | False |
-| `constraints`| string | Constraints to deploy the charm with | False |
-| `config`| map(string) | Map of the charm configuration options | False |
+| `model_uuid` | string | UUID of the model that the charm is deployed on | True |
+| `revision` | number | Revision number of the charm name | False |
+| `channel` | string | Channel that the charm is deployed from | False |
+| `constraints` | string | Constraints to deploy the charm with | False |
+| `config` | map(string) | Map of the charm configuration options | False |
 
 ### Outputs
 Upon applied, the module exports the following outputs:
 
 | Name | Description |
 | - | - |
-| `application`|  Deployed application object |
-| `provides`| Map of `provides` endpoints |
-| `requires`|  Map of `requires` endpoints |
+| `application` | Deployed application object |
+| `provides` | Map of `provides` endpoints |
+| `requires` | Map of `requires` endpoints |
 
 ## Usage
 
-This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+This module is intended to be used as part of a higher-level module. When defining one, ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so:
 
 ### Define a `juju_model` resource
 Define a `juju_model` resource and pass to the `model_uuid` input a reference to the `juju_model` resource's UUID. For example:

--- a/charms/api-server/terraform/README.md
+++ b/charms/api-server/terraform/README.md
@@ -1,0 +1,62 @@
+# Terraform module for Airflow API Server
+
+This is a Terraform module facilitating the deployment of the Airflow API Server charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `units` | number | Number of units to deploy | False |
+| `model_uuid`| string | UUID of the model that the charm is deployed on | True |
+| `revision`| number | Revision number of the charm name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `constraints`| string | Constraints to deploy the charm with | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `application`|  Deployed application object |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `requires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_uuid` input a reference to the `juju_model` resource's UUID. For example:
+
+```
+resource "juju_model" "testing" {
+  name = "airflow"
+}
+
+module "airflow-api-server-k8s" {
+  source     = "<path-to-this-directory>"
+  model_uuid = juju_model.testing.uuid
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_uuid` input a reference to the `data.juju_model` resource's UUID. This will enable Terraform to look for a `juju_model` resource with a UUID attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+
+```
+data "juju_model" "testing" {
+  uuid = var.model_uuid
+}
+
+module "airflow-api-server-k8s" {
+  source     = "<path-to-this-directory>"
+  model_uuid = data.juju_model.testing.uuid
+}
+```

--- a/charms/api-server/terraform/justfile
+++ b/charms/api-server/terraform/justfile
@@ -1,0 +1,67 @@
+set export := true # Just variables are exported into environment variables
+
+[private]
+default:
+    just --list
+
+[private]
+initialize:
+    #!/usr/bin/bash
+    if [ ! -d ".terraform" ]; then
+        terraform init
+    fi
+
+[private]
+destroy-model:
+    juju destroy-model --no-prompt --destroy-storage terraform || true
+
+[private]
+add-model: (destroy-model)
+    juju add-model terraform
+
+[private]
+validate_test_tfvars variables_file:
+    #!/usr/bin/bash
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
+
+# Run terraform format
+fmt: (initialize)
+    terraform fmt
+
+# Run terraform validate
+validate: (initialize)
+    terraform validate
+
+# Run tflint
+lint:
+    tflint
+
+# Apply the terraform plan with the provided variables file
+apply variables_file: (initialize)
+    terraform apply -auto-approve -var-file="${variables_file}"
+
+# Destroy the terraform plan with the provided variables file
+destroy variables_file:
+    #!/usr/bin/bash
+    terraform destroy -auto-approve -var-file="${variables_file}"
+
+    just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
+
+test:
+    #!/usr/bin/bash
+    set -euxo pipefail
+
+    trap 'just destroy "./test/test.tfvars"' EXIT
+
+    just add-model
+
+    just validate_test_tfvars "./test/test.tfvars"
+
+    just apply "./test/test.tfvars"
+
+    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Missing airflow-coordinator relation'))"

--- a/charms/api-server/terraform/main.tf
+++ b/charms/api-server/terraform/main.tf
@@ -1,0 +1,15 @@
+resource "juju_application" "airflow_api_server_k8s" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "airflow-api-server-k8s"
+    revision = var.revision
+    channel  = var.channel
+  }
+
+  constraints = var.constraints
+  config      = var.config
+
+  units = var.units
+}

--- a/charms/api-server/terraform/outputs.tf
+++ b/charms/api-server/terraform/outputs.tf
@@ -1,0 +1,13 @@
+output "application" {
+  value = juju_application.airflow_api_server_k8s
+}
+
+output "provides" {
+  value = {}
+}
+
+output "requires" {
+  value = {
+    airflow_coordinator = "airflow-coordinator"
+  }
+}

--- a/charms/api-server/terraform/test/test.tfvars
+++ b/charms/api-server/terraform/test/test.tfvars
@@ -1,0 +1,1 @@
+channel = "3.1/edge"

--- a/charms/api-server/terraform/variables.tf
+++ b/charms/api-server/terraform/variables.tf
@@ -1,0 +1,40 @@
+variable "app_name" {
+  type        = string
+  description = "Name of the deployed application"
+  default     = "airflow-api-server-k8s"
+}
+
+variable "channel" {
+  type        = string
+  description = "Charmhub channel to deploy the charm from"
+  default     = "edge"
+}
+
+variable "constraints" {
+  type        = string
+  description = "Constraints to be used when deploying this application"
+  default     = null
+}
+
+variable "config" {
+  type        = map(string)
+  description = "Configuration to deploy this application with"
+  default     = {}
+}
+
+variable "model_uuid" {
+  type        = string
+  description = "UUID of Juju model where the application is to be deployed"
+}
+
+variable "revision" {
+  type        = number
+  description = "Revision of the charm to deploy"
+  default     = null
+}
+
+variable "units" {
+  type        = number
+  description = "Number of units to deploy with this name and configuration"
+  default     = 1
+}

--- a/charms/api-server/terraform/versions.tf
+++ b/charms/api-server/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.12.2"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/charms/dag-processor/terraform/README.md
+++ b/charms/dag-processor/terraform/README.md
@@ -1,9 +1,11 @@
 # Terraform module for Airflow DAG Processor
 
-This is a Terraform module facilitating the deployment of the Airflow DAG Processor charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+This module deploys the Airflow DAG Processor charm using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For provider details, see the [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
 ## Requirements
-This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+- Terraform >= 1.12.2
+- Provider: `juju` >= 1.0.0
+- A Juju model must exist (see [Usage](#usage))
 
 ## API
 
@@ -12,26 +14,26 @@ The module offers the following configurable inputs:
 
 | Name | Type | Description | Required |
 | - | - | - | - |
-| `app_name`| string | Application name | False |
+| `app_name` | string | Name of the deployed application | False |
 | `units` | number | Number of units to deploy | False |
-| `model_uuid`| string | UUID of the model that the charm is deployed on | True |
-| `revision`| number | Revision number of the charm name | False |
-| `channel`| string | Channel that the charm is deployed from | False |
-| `constraints`| string | Constraints to deploy the charm with | False |
-| `config`| map(string) | Map of the charm configuration options | False |
+| `model_uuid` | string | UUID of the model that the charm is deployed on | True |
+| `revision` | number | Revision number of the charm name | False |
+| `channel` | string | Channel that the charm is deployed from | False |
+| `constraints` | string | Constraints to deploy the charm with | False |
+| `config` | map(string) | Map of the charm configuration options | False |
 
 ### Outputs
 Upon applied, the module exports the following outputs:
 
 | Name | Description |
 | - | - |
-| `application`|  Deployed application object |
-| `provides`| Map of `provides` endpoints |
-| `requires`|  Map of `requires` endpoints |
+| `application` | Deployed application object |
+| `provides` | Map of `provides` endpoints |
+| `requires` | Map of `requires` endpoints |
 
 ## Usage
 
-This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+This module is intended to be used as part of a higher-level module. When defining one, ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so:
 
 ### Define a `juju_model` resource
 Define a `juju_model` resource and pass to the `model_uuid` input a reference to the `juju_model` resource's UUID. For example:

--- a/charms/dag-processor/terraform/README.md
+++ b/charms/dag-processor/terraform/README.md
@@ -1,0 +1,62 @@
+# Terraform module for Airflow DAG Processor
+
+This is a Terraform module facilitating the deployment of the Airflow DAG Processor charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `units` | number | Number of units to deploy | False |
+| `model_uuid`| string | UUID of the model that the charm is deployed on | True |
+| `revision`| number | Revision number of the charm name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `constraints`| string | Constraints to deploy the charm with | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `application`|  Deployed application object |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `requires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_uuid` input a reference to the `juju_model` resource's UUID. For example:
+
+```
+resource "juju_model" "testing" {
+  name = "airflow"
+}
+
+module "airflow-dag-processor-k8s" {
+  source     = "<path-to-this-directory>"
+  model_uuid = juju_model.testing.uuid
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_uuid` input a reference to the `data.juju_model` resource's UUID. This will enable Terraform to look for a `juju_model` resource with a UUID attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+
+```
+data "juju_model" "testing" {
+  uuid = var.model_uuid
+}
+
+module "airflow-dag-processor-k8s" {
+  source     = "<path-to-this-directory>"
+  model_uuid = data.juju_model.testing.uuid
+}
+```

--- a/charms/dag-processor/terraform/justfile
+++ b/charms/dag-processor/terraform/justfile
@@ -1,0 +1,67 @@
+set export := true # Just variables are exported into environment variables
+
+[private]
+default:
+    just --list
+
+[private]
+initialize:
+    #!/usr/bin/bash
+    if [ ! -d ".terraform" ]; then
+        terraform init
+    fi
+
+[private]
+destroy-model:
+    juju destroy-model --no-prompt --destroy-storage terraform || true
+
+[private]
+add-model: (destroy-model)
+    juju add-model terraform
+
+[private]
+validate_test_tfvars variables_file:
+    #!/usr/bin/bash
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
+
+# Run terraform format
+fmt: (initialize)
+    terraform fmt
+
+# Run terraform validate
+validate: (initialize)
+    terraform validate
+
+# Run tflint
+lint:
+    tflint
+
+# Apply the terraform plan with the provided variables file
+apply variables_file: (initialize)
+    terraform apply -auto-approve -var-file="${variables_file}"
+
+# Destroy the terraform plan with the provided variables file
+destroy variables_file:
+    #!/usr/bin/bash
+    terraform destroy -auto-approve -var-file="${variables_file}"
+
+    just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
+
+test:
+    #!/usr/bin/bash
+    set -euxo pipefail
+
+    trap 'just destroy "./test/test.tfvars"' EXIT
+
+    just add-model
+
+    just validate_test_tfvars "./test/test.tfvars"
+
+    just apply "./test/test.tfvars"
+
+    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Missing airflow-coordinator relation'))"

--- a/charms/dag-processor/terraform/main.tf
+++ b/charms/dag-processor/terraform/main.tf
@@ -1,0 +1,15 @@
+resource "juju_application" "airflow_dag_processor_k8s" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "airflow-dag-processor-k8s"
+    revision = var.revision
+    channel  = var.channel
+  }
+
+  constraints = var.constraints
+  config      = var.config
+
+  units = var.units
+}

--- a/charms/dag-processor/terraform/outputs.tf
+++ b/charms/dag-processor/terraform/outputs.tf
@@ -1,0 +1,13 @@
+output "application" {
+  value = juju_application.airflow_dag_processor_k8s
+}
+
+output "provides" {
+  value = {}
+}
+
+output "requires" {
+  value = {
+    airflow_coordinator = "airflow-coordinator"
+  }
+}

--- a/charms/dag-processor/terraform/test/test.tfvars
+++ b/charms/dag-processor/terraform/test/test.tfvars
@@ -1,0 +1,1 @@
+channel = "3.1/edge"

--- a/charms/dag-processor/terraform/variables.tf
+++ b/charms/dag-processor/terraform/variables.tf
@@ -1,0 +1,40 @@
+variable "app_name" {
+  type        = string
+  description = "Name of the deployed application"
+  default     = "airflow-dag-processor-k8s"
+}
+
+variable "channel" {
+  type        = string
+  description = "Charmhub channel to deploy the charm from"
+  default     = "edge"
+}
+
+variable "constraints" {
+  type        = string
+  description = "Constraints to be used when deploying this application"
+  default     = null
+}
+
+variable "config" {
+  type        = map(string)
+  description = "Configuration to deploy this application with"
+  default     = {}
+}
+
+variable "model_uuid" {
+  type        = string
+  description = "UUID of Juju model where the application is to be deployed"
+}
+
+variable "revision" {
+  type        = number
+  description = "Revision of the charm to deploy"
+  default     = null
+}
+
+variable "units" {
+  type        = number
+  description = "Number of units to deploy with this name and configuration"
+  default     = 1
+}

--- a/charms/dag-processor/terraform/versions.tf
+++ b/charms/dag-processor/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.12.2"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/charms/scheduler/terraform/README.md
+++ b/charms/scheduler/terraform/README.md
@@ -1,9 +1,11 @@
 # Terraform module for Airflow Scheduler
 
-This is a Terraform module facilitating the deployment of the Airflow Scheduler charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+This module deploys the Airflow Scheduler charm using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For provider details, see the [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
 ## Requirements
-This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+- Terraform >= 1.12.2
+- Provider: `juju` >= 1.0.0
+- A Juju model must exist (see [Usage](#usage))
 
 ## API
 
@@ -12,26 +14,26 @@ The module offers the following configurable inputs:
 
 | Name | Type | Description | Required |
 | - | - | - | - |
-| `app_name`| string | Application name | False |
+| `app_name` | string | Name of the deployed application | False |
 | `units` | number | Number of units to deploy | False |
-| `model_uuid`| string | UUID of the model that the charm is deployed on | True |
-| `revision`| number | Revision number of the charm name | False |
-| `channel`| string | Channel that the charm is deployed from | False |
-| `constraints`| string | Constraints to deploy the charm with | False |
-| `config`| map(string) | Map of the charm configuration options | False |
+| `model_uuid` | string | UUID of the model that the charm is deployed on | True |
+| `revision` | number | Revision number of the charm name | False |
+| `channel` | string | Channel that the charm is deployed from | False |
+| `constraints` | string | Constraints to deploy the charm with | False |
+| `config` | map(string) | Map of the charm configuration options | False |
 
 ### Outputs
 Upon applied, the module exports the following outputs:
 
 | Name | Description |
 | - | - |
-| `application`|  Deployed application object |
-| `provides`| Map of `provides` endpoints |
-| `requires`|  Map of `requires` endpoints |
+| `application` | Deployed application object |
+| `provides` | Map of `provides` endpoints |
+| `requires` | Map of `requires` endpoints |
 
 ## Usage
 
-This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+This module is intended to be used as part of a higher-level module. When defining one, ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so:
 
 ### Define a `juju_model` resource
 Define a `juju_model` resource and pass to the `model_uuid` input a reference to the `juju_model` resource's UUID. For example:

--- a/charms/scheduler/terraform/README.md
+++ b/charms/scheduler/terraform/README.md
@@ -1,0 +1,62 @@
+# Terraform module for Airflow Scheduler
+
+This is a Terraform module facilitating the deployment of the Airflow Scheduler charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `units` | number | Number of units to deploy | False |
+| `model_uuid`| string | UUID of the model that the charm is deployed on | True |
+| `revision`| number | Revision number of the charm name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `constraints`| string | Constraints to deploy the charm with | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `application`|  Deployed application object |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `requires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_uuid` input a reference to the `juju_model` resource's UUID. For example:
+
+```
+resource "juju_model" "testing" {
+  name = "airflow"
+}
+
+module "airflow-scheduler-k8s" {
+  source     = "<path-to-this-directory>"
+  model_uuid = juju_model.testing.uuid
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_uuid` input a reference to the `data.juju_model` resource's UUID. This will enable Terraform to look for a `juju_model` resource with a UUID attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+
+```
+data "juju_model" "testing" {
+  uuid = var.model_uuid
+}
+
+module "airflow-scheduler-k8s" {
+  source     = "<path-to-this-directory>"
+  model_uuid = data.juju_model.testing.uuid
+}
+```

--- a/charms/scheduler/terraform/justfile
+++ b/charms/scheduler/terraform/justfile
@@ -1,0 +1,67 @@
+set export := true # Just variables are exported into environment variables
+
+[private]
+default:
+    just --list
+
+[private]
+initialize:
+    #!/usr/bin/bash
+    if [ ! -d ".terraform" ]; then
+        terraform init
+    fi
+
+[private]
+destroy-model:
+    juju destroy-model --no-prompt --destroy-storage terraform || true
+
+[private]
+add-model: (destroy-model)
+    juju add-model terraform
+
+[private]
+validate_test_tfvars variables_file:
+    #!/usr/bin/bash
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
+
+# Run terraform format
+fmt: (initialize)
+    terraform fmt
+
+# Run terraform validate
+validate: (initialize)
+    terraform validate
+
+# Run tflint
+lint:
+    tflint
+
+# Apply the terraform plan with the provided variables file
+apply variables_file: (initialize)
+    terraform apply -auto-approve -var-file="${variables_file}"
+
+# Destroy the terraform plan with the provided variables file
+destroy variables_file:
+    #!/usr/bin/bash
+    terraform destroy -auto-approve -var-file="${variables_file}"
+
+    just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
+
+test:
+    #!/usr/bin/bash
+    set -euxo pipefail
+
+    trap 'just destroy "./test/test.tfvars"' EXIT
+
+    just add-model
+
+    just validate_test_tfvars "./test/test.tfvars"
+
+    just apply "./test/test.tfvars"
+
+    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Missing airflow-coordinator relation'))"

--- a/charms/scheduler/terraform/main.tf
+++ b/charms/scheduler/terraform/main.tf
@@ -1,0 +1,15 @@
+resource "juju_application" "airflow_scheduler_k8s" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "airflow-scheduler-k8s"
+    revision = var.revision
+    channel  = var.channel
+  }
+
+  constraints = var.constraints
+  config      = var.config
+
+  units = var.units
+}

--- a/charms/scheduler/terraform/outputs.tf
+++ b/charms/scheduler/terraform/outputs.tf
@@ -1,0 +1,13 @@
+output "application" {
+  value = juju_application.airflow_scheduler_k8s
+}
+
+output "provides" {
+  value = {}
+}
+
+output "requires" {
+  value = {
+    airflow_coordinator = "airflow-coordinator"
+  }
+}

--- a/charms/scheduler/terraform/test/test.tfvars
+++ b/charms/scheduler/terraform/test/test.tfvars
@@ -1,0 +1,1 @@
+channel = "3.1/edge"

--- a/charms/scheduler/terraform/variables.tf
+++ b/charms/scheduler/terraform/variables.tf
@@ -1,0 +1,40 @@
+variable "app_name" {
+  type        = string
+  description = "Name of the deployed application"
+  default     = "airflow-scheduler-k8s"
+}
+
+variable "channel" {
+  type        = string
+  description = "Charmhub channel to deploy the charm from"
+  default     = "edge"
+}
+
+variable "constraints" {
+  type        = string
+  description = "Constraints to be used when deploying this application"
+  default     = null
+}
+
+variable "config" {
+  type        = map(string)
+  description = "Configuration to deploy this application with"
+  default     = {}
+}
+
+variable "model_uuid" {
+  type        = string
+  description = "UUID of Juju model where the application is to be deployed"
+}
+
+variable "revision" {
+  type        = number
+  description = "Revision of the charm to deploy"
+  default     = null
+}
+
+variable "units" {
+  type        = number
+  description = "Number of units to deploy with this name and configuration"
+  default     = 1
+}

--- a/charms/scheduler/terraform/versions.tf
+++ b/charms/scheduler/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.12.2"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/charms/triggerer/terraform/README.md
+++ b/charms/triggerer/terraform/README.md
@@ -1,0 +1,62 @@
+# Terraform module for Airflow Triggerer
+
+This is a Terraform module facilitating the deployment of the Airflow Triggerer charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `units` | number | Number of units to deploy | False |
+| `model_uuid`| string | UUID of the model that the charm is deployed on | True |
+| `revision`| number | Revision number of the charm name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `constraints`| string | Constraints to deploy the charm with | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `application`|  Deployed application object |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `requires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_uuid` input a reference to the `juju_model` resource's UUID. For example:
+
+```
+resource "juju_model" "testing" {
+  name = "airflow"
+}
+
+module "airflow-triggerer-k8s" {
+  source     = "<path-to-this-directory>"
+  model_uuid = juju_model.testing.uuid
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_uuid` input a reference to the `data.juju_model` resource's UUID. This will enable Terraform to look for a `juju_model` resource with a UUID attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+
+```
+data "juju_model" "testing" {
+  uuid = var.model_uuid
+}
+
+module "airflow-triggerer-k8s" {
+  source     = "<path-to-this-directory>"
+  model_uuid = data.juju_model.testing.uuid
+}
+```

--- a/charms/triggerer/terraform/README.md
+++ b/charms/triggerer/terraform/README.md
@@ -1,9 +1,11 @@
 # Terraform module for Airflow Triggerer
 
-This is a Terraform module facilitating the deployment of the Airflow Triggerer charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+This module deploys the Airflow Triggerer charm using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For provider details, see the [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
 ## Requirements
-This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+- Terraform >= 1.12.2
+- Provider: `juju` >= 1.0.0
+- A Juju model must exist (see [Usage](#usage))
 
 ## API
 
@@ -12,26 +14,26 @@ The module offers the following configurable inputs:
 
 | Name | Type | Description | Required |
 | - | - | - | - |
-| `app_name`| string | Application name | False |
+| `app_name` | string | Name of the deployed application | False |
 | `units` | number | Number of units to deploy | False |
-| `model_uuid`| string | UUID of the model that the charm is deployed on | True |
-| `revision`| number | Revision number of the charm name | False |
-| `channel`| string | Channel that the charm is deployed from | False |
-| `constraints`| string | Constraints to deploy the charm with | False |
-| `config`| map(string) | Map of the charm configuration options | False |
+| `model_uuid` | string | UUID of the model that the charm is deployed on | True |
+| `revision` | number | Revision number of the charm name | False |
+| `channel` | string | Channel that the charm is deployed from | False |
+| `constraints` | string | Constraints to deploy the charm with | False |
+| `config` | map(string) | Map of the charm configuration options | False |
 
 ### Outputs
 Upon applied, the module exports the following outputs:
 
 | Name | Description |
 | - | - |
-| `application`|  Deployed application object |
-| `provides`| Map of `provides` endpoints |
-| `requires`|  Map of `requires` endpoints |
+| `application` | Deployed application object |
+| `provides` | Map of `provides` endpoints |
+| `requires` | Map of `requires` endpoints |
 
 ## Usage
 
-This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+This module is intended to be used as part of a higher-level module. When defining one, ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so:
 
 ### Define a `juju_model` resource
 Define a `juju_model` resource and pass to the `model_uuid` input a reference to the `juju_model` resource's UUID. For example:

--- a/charms/triggerer/terraform/justfile
+++ b/charms/triggerer/terraform/justfile
@@ -1,0 +1,67 @@
+set export := true # Just variables are exported into environment variables
+
+[private]
+default:
+    just --list
+
+[private]
+initialize:
+    #!/usr/bin/bash
+    if [ ! -d ".terraform" ]; then
+        terraform init
+    fi
+
+[private]
+destroy-model:
+    juju destroy-model --no-prompt --destroy-storage terraform || true
+
+[private]
+add-model: (destroy-model)
+    juju add-model terraform
+
+[private]
+validate_test_tfvars variables_file:
+    #!/usr/bin/bash
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
+
+# Run terraform format
+fmt: (initialize)
+    terraform fmt
+
+# Run terraform validate
+validate: (initialize)
+    terraform validate
+
+# Run tflint
+lint:
+    tflint
+
+# Apply the terraform plan with the provided variables file
+apply variables_file: (initialize)
+    terraform apply -auto-approve -var-file="${variables_file}"
+
+# Destroy the terraform plan with the provided variables file
+destroy variables_file:
+    #!/usr/bin/bash
+    terraform destroy -auto-approve -var-file="${variables_file}"
+
+    just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
+
+test:
+    #!/usr/bin/bash
+    set -euxo pipefail
+
+    trap 'just destroy "./test/test.tfvars"' EXIT
+
+    just add-model
+
+    just validate_test_tfvars "./test/test.tfvars"
+
+    just apply "./test/test.tfvars"
+
+    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Missing airflow-coordinator relation'))"

--- a/charms/triggerer/terraform/main.tf
+++ b/charms/triggerer/terraform/main.tf
@@ -1,0 +1,15 @@
+resource "juju_application" "airflow_triggerer_k8s" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "airflow-triggerer-k8s"
+    revision = var.revision
+    channel  = var.channel
+  }
+
+  constraints = var.constraints
+  config      = var.config
+
+  units = var.units
+}

--- a/charms/triggerer/terraform/outputs.tf
+++ b/charms/triggerer/terraform/outputs.tf
@@ -1,0 +1,13 @@
+output "application" {
+  value = juju_application.airflow_triggerer_k8s
+}
+
+output "provides" {
+  value = {}
+}
+
+output "requires" {
+  value = {
+    airflow_coordinator = "airflow-coordinator"
+  }
+}

--- a/charms/triggerer/terraform/test/test.tfvars
+++ b/charms/triggerer/terraform/test/test.tfvars
@@ -1,0 +1,1 @@
+channel = "3.1/edge"

--- a/charms/triggerer/terraform/variables.tf
+++ b/charms/triggerer/terraform/variables.tf
@@ -1,0 +1,40 @@
+variable "app_name" {
+  type        = string
+  description = "Name of the deployed application"
+  default     = "airflow-triggerer-k8s"
+}
+
+variable "channel" {
+  type        = string
+  description = "Charmhub channel to deploy the charm from"
+  default     = "edge"
+}
+
+variable "constraints" {
+  type        = string
+  description = "Constraints to be used when deploying this application"
+  default     = null
+}
+
+variable "config" {
+  type        = map(string)
+  description = "Configuration to deploy this application with"
+  default     = {}
+}
+
+variable "model_uuid" {
+  type        = string
+  description = "UUID of Juju model where the application is to be deployed"
+}
+
+variable "revision" {
+  type        = number
+  description = "Revision of the charm to deploy"
+  default     = null
+}
+
+variable "units" {
+  type        = number
+  description = "Number of units to deploy with this name and configuration"
+  default     = 1
+}

--- a/charms/triggerer/terraform/versions.tf
+++ b/charms/triggerer/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.12.2"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR builds terraform modules for all airflow core charms.
Reference Spec: [Charm Terraform Standards](https://docs.google.com/document/d/1k1psLCfcf0Nr5KeVtWGFi9wmzhcg5AP9GVZTsRyVQSQ/edit?tab=t.0)
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
