### PR TITLE
[WF-282] Adding justfile and CI workflow to test

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,22 @@
+name: Terraform checks
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  pull-request-terraform-checks:
+    name: PR Terraform checks
+    strategy:
+      matrix:
+        module-directory:
+          - charms/api-server/terraform
+          - charms/dag-processor/terraform
+          - charms/scheduler/terraform
+          - charms/triggerer/terraform
+    uses: canonical/workflows-team/.github/workflows/terraform.yaml@main
+    with:
+      module-directory: ${{ matrix.module-directory }}

--- a/charms/api-server/terraform/justfile
+++ b/charms/api-server/terraform/justfile
@@ -1,0 +1,67 @@
+set export := true # Just variables are exported into environment variables
+
+[private]
+default:
+    just --list
+
+[private]
+initialize:
+    #!/usr/bin/bash
+    if [ ! -d ".terraform" ]; then
+        terraform init
+    fi
+
+[private]
+destroy-model:
+    juju destroy-model --no-prompt --destroy-storage terraform || true
+
+[private]
+add-model: (destroy-model)
+    juju add-model terraform
+
+[private]
+validate_test_tfvars variables_file:
+    #!/usr/bin/bash
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
+
+# Run terraform format
+fmt: (initialize)
+    terraform fmt
+
+# Run terraform validate
+validate: (initialize)
+    terraform validate
+
+# Run tflint
+lint:
+    tflint
+
+# Apply the terraform plan with the provided variables file
+apply variables_file: (initialize)
+    terraform apply -auto-approve -var-file="${variables_file}"
+
+# Destroy the terraform plan with the provided variables file
+destroy variables_file:
+    #!/usr/bin/bash
+    terraform destroy -auto-approve -var-file="${variables_file}"
+
+    just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
+
+test:
+    #!/usr/bin/bash
+    set -euxo pipefail
+
+    trap 'just destroy "./test/test.tfvars"' EXIT
+
+    just add-model
+
+    just validate_test_tfvars "./test/test.tfvars"
+
+    just apply "./test/test.tfvars"
+
+    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Missing airflow-coordinator relation'))"

--- a/charms/api-server/terraform/test/test.tfvars
+++ b/charms/api-server/terraform/test/test.tfvars
@@ -1,0 +1,1 @@
+channel = "3.1/edge"

--- a/charms/dag-processor/terraform/justfile
+++ b/charms/dag-processor/terraform/justfile
@@ -1,0 +1,67 @@
+set export := true # Just variables are exported into environment variables
+
+[private]
+default:
+    just --list
+
+[private]
+initialize:
+    #!/usr/bin/bash
+    if [ ! -d ".terraform" ]; then
+        terraform init
+    fi
+
+[private]
+destroy-model:
+    juju destroy-model --no-prompt --destroy-storage terraform || true
+
+[private]
+add-model: (destroy-model)
+    juju add-model terraform
+
+[private]
+validate_test_tfvars variables_file:
+    #!/usr/bin/bash
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
+
+# Run terraform format
+fmt: (initialize)
+    terraform fmt
+
+# Run terraform validate
+validate: (initialize)
+    terraform validate
+
+# Run tflint
+lint:
+    tflint
+
+# Apply the terraform plan with the provided variables file
+apply variables_file: (initialize)
+    terraform apply -auto-approve -var-file="${variables_file}"
+
+# Destroy the terraform plan with the provided variables file
+destroy variables_file:
+    #!/usr/bin/bash
+    terraform destroy -auto-approve -var-file="${variables_file}"
+
+    just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
+
+test:
+    #!/usr/bin/bash
+    set -euxo pipefail
+
+    trap 'just destroy "./test/test.tfvars"' EXIT
+
+    just add-model
+
+    just validate_test_tfvars "./test/test.tfvars"
+
+    just apply "./test/test.tfvars"
+
+    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Missing airflow-coordinator relation'))"

--- a/charms/dag-processor/terraform/test/test.tfvars
+++ b/charms/dag-processor/terraform/test/test.tfvars
@@ -1,0 +1,1 @@
+channel = "3.1/edge"

--- a/charms/scheduler/terraform/justfile
+++ b/charms/scheduler/terraform/justfile
@@ -1,0 +1,67 @@
+set export := true # Just variables are exported into environment variables
+
+[private]
+default:
+    just --list
+
+[private]
+initialize:
+    #!/usr/bin/bash
+    if [ ! -d ".terraform" ]; then
+        terraform init
+    fi
+
+[private]
+destroy-model:
+    juju destroy-model --no-prompt --destroy-storage terraform || true
+
+[private]
+add-model: (destroy-model)
+    juju add-model terraform
+
+[private]
+validate_test_tfvars variables_file:
+    #!/usr/bin/bash
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
+
+# Run terraform format
+fmt: (initialize)
+    terraform fmt
+
+# Run terraform validate
+validate: (initialize)
+    terraform validate
+
+# Run tflint
+lint:
+    tflint
+
+# Apply the terraform plan with the provided variables file
+apply variables_file: (initialize)
+    terraform apply -auto-approve -var-file="${variables_file}"
+
+# Destroy the terraform plan with the provided variables file
+destroy variables_file:
+    #!/usr/bin/bash
+    terraform destroy -auto-approve -var-file="${variables_file}"
+
+    just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
+
+test:
+    #!/usr/bin/bash
+    set -euxo pipefail
+
+    trap 'just destroy "./test/test.tfvars"' EXIT
+
+    just add-model
+
+    just validate_test_tfvars "./test/test.tfvars"
+
+    just apply "./test/test.tfvars"
+
+    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Missing airflow-coordinator relation'))"

--- a/charms/scheduler/terraform/test/test.tfvars
+++ b/charms/scheduler/terraform/test/test.tfvars
@@ -1,0 +1,1 @@
+channel = "3.1/edge"

--- a/charms/triggerer/terraform/justfile
+++ b/charms/triggerer/terraform/justfile
@@ -1,0 +1,67 @@
+set export := true # Just variables are exported into environment variables
+
+[private]
+default:
+    just --list
+
+[private]
+initialize:
+    #!/usr/bin/bash
+    if [ ! -d ".terraform" ]; then
+        terraform init
+    fi
+
+[private]
+destroy-model:
+    juju destroy-model --no-prompt --destroy-storage terraform || true
+
+[private]
+add-model: (destroy-model)
+    juju add-model terraform
+
+[private]
+validate_test_tfvars variables_file:
+    #!/usr/bin/bash
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
+
+# Run terraform format
+fmt: (initialize)
+    terraform fmt
+
+# Run terraform validate
+validate: (initialize)
+    terraform validate
+
+# Run tflint
+lint:
+    tflint
+
+# Apply the terraform plan with the provided variables file
+apply variables_file: (initialize)
+    terraform apply -auto-approve -var-file="${variables_file}"
+
+# Destroy the terraform plan with the provided variables file
+destroy variables_file:
+    #!/usr/bin/bash
+    terraform destroy -auto-approve -var-file="${variables_file}"
+
+    just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
+
+test:
+    #!/usr/bin/bash
+    set -euxo pipefail
+
+    trap 'just destroy "./test/test.tfvars"' EXIT
+
+    just add-model
+
+    just validate_test_tfvars "./test/test.tfvars"
+
+    just apply "./test/test.tfvars"
+
+    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Missing airflow-coordinator relation'))"

--- a/charms/triggerer/terraform/test/test.tfvars
+++ b/charms/triggerer/terraform/test/test.tfvars
@@ -1,0 +1,1 @@
+channel = "3.1/edge"


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR adds a just file to test out the terraform modules for all airflow core charms.  a CI workflow terraform.yaml uses [workflow](https://github.com/canonical/workflows-team/blob/main/.github/workflows/terraform.yaml) from workflow-team repo.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
