### PR TITLE
[WF-288] Implement airflow api server relation charm lib + add provides interface

### DIFF
--- a/charms/api-server/charmcraft.yaml
+++ b/charms/api-server/charmcraft.yaml
@@ -28,6 +28,11 @@ resources:
     description: OCI image for the airflow api server container
     upstream-source: ubuntu/airflow:3.1-24.04_edge
 
+provides:
+  airflow-api-server:
+    interface: airflow_api_server
+    limit: 1
+
 requires:
   airflow-coordinator:
     interface: airflow_coordinator

--- a/charms/api-server/lib/charms/airflow_api_server_k8s/v0/airflow_api_server.py
+++ b/charms/api-server/lib/charms/airflow_api_server_k8s/v0/airflow_api_server.py
@@ -1,0 +1,92 @@
+"""TODO: Add a proper docstring here.
+"""
+
+import logging
+import ops
+import typing
+
+# The unique Charmhub library identifier, never change it
+LIBID = "a0959775f225419d86d202cd754066cf"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+HOST_KEY = "host"
+PORT_KEY = "port"
+
+logger = logging.getLogger(__name__)
+
+
+class AirflowAPIServerProvides(ops.Object):
+    """A provider handler encapsulating the airflow api server relation."""
+
+    def __init__(
+        self,
+        charm: ops.CharmBase,
+        relation_name: str,
+        host: str,
+        port: str,
+    ):
+        super().__init__(charm, relation_name)
+
+        self._charm = charm
+        self._relation = charm.model.get_relation(relation_name)
+
+        self._set_api_server_host_info(host, port)
+
+    def _set_api_server_host_info(self, host: str, port: str):
+        """Write the API server host and port to the relation."""
+        if not self._relation or not self._charm.unit.is_leader():
+            return
+
+        if not host:
+            logger.error("Invalid host to set in airflow_api_server relation")
+            return
+
+        if not port:
+            logger.error("Invalid port to set in airflow_api_server relation")
+            return
+
+        self._relation.data[self._charm.app][HOST_KEY] = host
+        self._relation.data[self._charm.app][PORT_KEY] = port
+
+
+class AirflowAPIServerRequires(ops.Object):
+    """A requirer handler encapsulating the airflow api server relation."""
+
+    def __init__(
+        self,
+        charm: ops.CharmBase,
+        relation_name: str,
+        callback: typing.Callable,
+    ):
+        super().__init__(charm, relation_name)
+
+        self._charm = charm
+        self._relation = charm.model.get_relation(relation_name)
+
+        for event in [
+            charm.on[relation_name].relation_changed,
+            charm.on[relation_name].relation_broken,
+        ]:
+            self.framework.observe(event, callback)
+
+    @property
+    def api_server_host(self) -> typing.Optional[str]:
+        """Return API server (host, port) tuple."""
+        if not self._relation or not self._relation.app:
+            return None
+
+        return self._relation.data[self._relation.app].get(HOST_KEY)
+
+    @property
+    def api_server_port(self) -> typing.Optional[str]:
+        """Return API server (host, port) tuple."""
+        if not self._relation or not self._relation.app:
+            return None
+
+        return self._relation.data[self._relation.app].get(PORT_KEY)

--- a/charms/api-server/lib/charms/airflow_api_server_k8s/v0/airflow_api_server.py
+++ b/charms/api-server/lib/charms/airflow_api_server_k8s/v0/airflow_api_server.py
@@ -1,4 +1,52 @@
-"""TODO: Add a proper docstring here.
+""" Library to manage the relation provided by Airflow API Server charm.
+
+This library contains the Requires and Provides classes for handing the relation
+between the Airflow API Server charm and the Airflow Coordinator charm. This
+relation interface provides a way for the API server charm to convey information
+that will affect the global `airflow.cfg` file distributed by Airflow Coordinator.
+
+### Requirer Charm
+
+The following presents an example usage of the AirflowAPIServerRequires class:
+
+```python
+import charms.airflow_api_server_k8s.v0.airflow_api_server as airflow_api_server
+
+class AirflowCoordinatorCharm(ops.CharmBase):
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+        self.requirer = airflow_api_server.AirflowAPIServerRequires(
+            self,
+            "airflow-api-server", # relation endpoint
+            callback=self.reconcile,
+        )
+
+    def reconcile(self, event) -> None:
+        # Access the API server host and port
+        self.requirer.api_server_host
+        self.requirer.api_server_port
+```
+
+### Provider Charm
+
+The following presents an example usage of the AirflowAPIServerProvides class:
+
+```python
+import charms.airflow_api_server_k8s.v0.airflow_api_server as airflow_api_server
+
+class AirflowAPIServerCharm(ops.CharmBase):
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+        self.requirer = airflow_api_server.AirflowAPIServerProviders(
+            self,
+            "airflow-api-server", # relation endpoint
+            "airflow-api-server-k8s-endpoints.airflow-model.svc.cluster.local", # host
+            "8080", # port
+        )
+```
+
 """
 
 import logging

--- a/charms/api-server/lib/charms/airflow_api_server_k8s/v0/airflow_api_server.py
+++ b/charms/api-server/lib/charms/airflow_api_server_k8s/v0/airflow_api_server.py
@@ -126,7 +126,7 @@ class AirflowAPIServerRequires(ops.Object):
 
     @property
     def api_server_host(self) -> typing.Optional[str]:
-        """Return API server (host, port) tuple."""
+        """Return API server host."""
         if not self._relation or not self._relation.app:
             return None
 
@@ -134,7 +134,7 @@ class AirflowAPIServerRequires(ops.Object):
 
     @property
     def api_server_port(self) -> typing.Optional[str]:
-        """Return API server (host, port) tuple."""
+        """Return API server port."""
         if not self._relation or not self._relation.app:
             return None
 

--- a/charms/api-server/lib/charms/airflow_api_server_k8s/v0/airflow_api_server.py
+++ b/charms/api-server/lib/charms/airflow_api_server_k8s/v0/airflow_api_server.py
@@ -1,4 +1,4 @@
-""" Library to manage the relation provided by Airflow API Server charm.
+"""Library to manage the relation provided by Airflow API Server charm.
 
 This library contains the Requires and Provides classes for handing the relation
 between the Airflow API Server charm and the Airflow Coordinator charm. This
@@ -50,8 +50,9 @@ class AirflowAPIServerCharm(ops.CharmBase):
 """
 
 import logging
-import ops
 import typing
+
+import ops
 
 # The unique Charmhub library identifier, never change it
 LIBID = "a0959775f225419d86d202cd754066cf"

--- a/charms/api-server/src/charm.py
+++ b/charms/api-server/src/charm.py
@@ -7,6 +7,7 @@
 import logging
 
 import ops
+from charms.airflow_api_server_k8s.v0.airflow_api_server import AirflowAPIServerProvides
 from charms.airflow_coordinator_k8s.v0.airflow_coordinator import AirflowCoordinatorRequires
 
 import constants
@@ -27,6 +28,7 @@ class ExitWithStatusError(Exception):
         """Return the Juju unit status represented by this exception."""
         return self.status_type(self.msg)
 
+
 class AirflowApiServerCharm(ops.CharmBase):
     """Charm the Airflow API Server."""
 
@@ -38,10 +40,17 @@ class AirflowApiServerCharm(ops.CharmBase):
         self._container = self.unit.get_container(constants.CONTAINER_NAME)
         self._config_requires = AirflowCoordinatorRequires(
             charm=self,
-            relation_name=constants.AIRFLOW_COORDINATOR_RELATION_NAME,
+            relation_name=constants.AIRFLOW_COORDINATOR_RELATION_ENDPOINT,
             component=constants.AIRFLOW_COMPONENT,
             workload_container=self._container,
             callback=self._reconcile,
+        )
+
+        self._api_server_provides = AirflowAPIServerProvides(
+            self,
+            constants.AIRFLOW_API_SERVER_RELATION_ENDPOINT,
+            f"{self.app.name}-endpoints.{self.model.name}.svc.cluster.local",
+            "8080",
         )
 
     def _stop_service_and_remove_config(self) -> None:
@@ -66,7 +75,7 @@ class AirflowApiServerCharm(ops.CharmBase):
 
     def _check_required_relations(self) -> None:
         """Check if required relations are established."""
-        if not self.model.get_relation(constants.AIRFLOW_COORDINATOR_RELATION_NAME):
+        if not self.model.get_relation(constants.AIRFLOW_COORDINATOR_RELATION_ENDPOINT):
             self._stop_service_and_remove_config()
             raise ExitWithStatusError(
                 "Missing airflow-coordinator relation",

--- a/charms/api-server/src/charm.py
+++ b/charms/api-server/src/charm.py
@@ -49,9 +49,21 @@ class AirflowApiServerCharm(ops.CharmBase):
         self._api_server_provides = AirflowAPIServerProvides(
             self,
             constants.AIRFLOW_API_SERVER_RELATION_ENDPOINT,
-            f"{self.app.name}-endpoints.{self.model.name}.svc.cluster.local",
-            "8080",
+            self._airflow_api_server_host,
+            str(self._airflow_api_server_port),
         )
+
+    @property
+    def _airflow_api_server_host(self) -> str:
+        """Airflow API Server hostname."""
+        # Hard-coded, but subject to change with addition of features like
+        # ingress or configurable options of the type of K8s service for the application
+        return f"{self.app.name}-endpoints.{self.model.name}.svc.cluster.local"
+
+    @property
+    def _airflow_api_server_port(self) -> int:
+        """Airflow API Server port."""
+        return 8080
 
     def _stop_service_and_remove_config(self) -> None:
         try:

--- a/charms/api-server/src/constants.py
+++ b/charms/api-server/src/constants.py
@@ -3,6 +3,9 @@
 SERVICE_NAME = "airflow"
 CONTAINER_NAME = "airflow-api-server"
 AIRFLOW_COMPONENT = "api-server"
-AIRFLOW_COORDINATOR_RELATION_NAME = "airflow-coordinator"
+
+AIRFLOW_COORDINATOR_RELATION_ENDPOINT = "airflow-coordinator"
+AIRFLOW_API_SERVER_RELATION_ENDPOINT = "airflow-api-server"
+
 AIRFLOW_HOME = "/opt/airflow"
 AIRFLOW_CONFIG_PATH = f"{AIRFLOW_HOME}/airflow.cfg"

--- a/charms/api-server/tests/scenario/test_airflow_api_server.py
+++ b/charms/api-server/tests/scenario/test_airflow_api_server.py
@@ -123,6 +123,7 @@ def requires_application_state(airflow_api_server_requires_relation):
 
 class TestAirflowAPIServerProvides:
     def test_missing_relation(self, provides_application_context, provides_application_state):
+        """Confirms that the _reconcile handler not run if the relation is missing."""
         provides_application_state = dataclasses.replace(provides_application_state, relations=[])
 
         state_out = provides_application_context.run(
@@ -131,6 +132,7 @@ class TestAirflowAPIServerProvides:
         assert state_out.unit_status == ops.ActiveStatus()
 
     def test_non_leader_noop(self, provides_application_context, provides_application_state):
+        """Confirms the _reconcile handler no-ops if it is not the leader unit."""
         provides_application_state = dataclasses.replace(provides_application_state, leader=False)
 
         state_out = provides_application_context.run(
@@ -148,6 +150,7 @@ class TestAirflowAPIServerProvides:
     def test_successful_set_of_data(
         self, provides_application_context, provides_application_state
     ):
+        """Ensures proper write of data in the relation databag."""
         state_out = provides_application_context.run(
             provides_application_context.on.start(), provides_application_state
         )
@@ -167,11 +170,13 @@ class TestAirflowAPIServerProvides:
 
 class TestAirflowAPIServerRequires:
     def get_juju_log_line(self, log_level: str, event: ops.EventBase):
+        """Composes specific expected logs from mock charms."""
         return ops.testing.JujuLogLine(
             level=log_level, message=f"§Requirer reacting to event: {event}"
         )
 
     def test_missing_relation(self, requires_application_context, requires_application_state):
+        """Confirms proper null data when relation is missing."""
         requires_application_state = dataclasses.replace(requires_application_state, relations=[])
 
         with requires_application_context(
@@ -194,6 +199,7 @@ class TestAirflowAPIServerRequires:
         requires_application_state,
         airflow_api_server_requires_relation,
     ):
+        """Confirms proper data access when first available and subsequently updated."""
         with requires_application_context(
             requires_application_context.on.relation_changed(airflow_api_server_requires_relation),
             requires_application_state,
@@ -236,6 +242,7 @@ class TestAirflowAPIServerRequires:
         requires_application_state,
         airflow_api_server_requires_relation,
     ):
+        """Confirms null data access when relation broken."""
         with requires_application_context(
             requires_application_context.on.relation_broken(airflow_api_server_requires_relation),
             requires_application_state,

--- a/charms/api-server/tests/scenario/test_airflow_api_server.py
+++ b/charms/api-server/tests/scenario/test_airflow_api_server.py
@@ -7,7 +7,10 @@ import logging
 import ops
 import ops.testing
 import pytest
-from charms.airflow_api_server_k8s.v0.airflow_api_server import AirflowAPIServerProvides, AirflowAPIServerRequires
+from charms.airflow_api_server_k8s.v0.airflow_api_server import (
+    AirflowAPIServerProvides,
+    AirflowAPIServerRequires,
+)
 
 import constants
 
@@ -117,6 +120,7 @@ def requires_application_state(airflow_api_server_requires_relation):
         relations=[airflow_api_server_requires_relation],
     )
 
+
 class TestAirflowAPIServerProvides:
     def test_missing_relation(self, provides_application_context, provides_application_state):
         provides_application_state = dataclasses.replace(provides_application_state, relations=[])
@@ -170,7 +174,9 @@ class TestAirflowAPIServerRequires:
     def test_missing_relation(self, requires_application_context, requires_application_state):
         requires_application_state = dataclasses.replace(requires_application_state, relations=[])
 
-        with requires_application_context(requires_application_context.on.start(), requires_application_state) as manager:
+        with requires_application_context(
+            requires_application_context.on.start(), requires_application_state
+        ) as manager:
             state_out = manager.run()
 
             assert (
@@ -182,8 +188,16 @@ class TestAirflowAPIServerRequires:
             assert manager.charm.requires.api_server_host is None
             assert manager.charm.requires.api_server_port is None
 
-    def test_valid_relation(self, requires_application_context, requires_application_state, airflow_api_server_requires_relation):
-        with requires_application_context(requires_application_context.on.relation_changed(airflow_api_server_requires_relation), requires_application_state) as manager:
+    def test_valid_relation(
+        self,
+        requires_application_context,
+        requires_application_state,
+        airflow_api_server_requires_relation,
+    ):
+        with requires_application_context(
+            requires_application_context.on.relation_changed(airflow_api_server_requires_relation),
+            requires_application_state,
+        ) as manager:
             state_out = manager.run()
 
             assert (
@@ -195,11 +209,16 @@ class TestAirflowAPIServerRequires:
             assert manager.charm.requires.api_server_host == "test-receiving-host"
             assert manager.charm.requires.api_server_port == "test-receiving-port"
 
-        updated_relation = dataclasses.replace(airflow_api_server_requires_relation, remote_app_data={"host": "updated-receiving-host", "port": "updated-receiving-port"})
+        updated_relation = dataclasses.replace(
+            airflow_api_server_requires_relation,
+            remote_app_data={"host": "updated-receiving-host", "port": "updated-receiving-port"},
+        )
         updated_state = dataclasses.replace(state_out, relations=[updated_relation])
         updated_state = dataclasses.replace(updated_state, unit_status=ops.WaitingStatus())
 
-        with requires_application_context(requires_application_context.on.relation_changed(updated_relation), updated_state) as manager:
+        with requires_application_context(
+            requires_application_context.on.relation_changed(updated_relation), updated_state
+        ) as manager:
             state_out = manager.run()
 
             assert (
@@ -211,8 +230,16 @@ class TestAirflowAPIServerRequires:
             assert manager.charm.requires.api_server_host == "updated-receiving-host"
             assert manager.charm.requires.api_server_port == "updated-receiving-port"
 
-    def test_relation_break(self, requires_application_context, requires_application_state, airflow_api_server_requires_relation):
-        with requires_application_context(requires_application_context.on.relation_broken(airflow_api_server_requires_relation), requires_application_state) as manager:
+    def test_relation_break(
+        self,
+        requires_application_context,
+        requires_application_state,
+        airflow_api_server_requires_relation,
+    ):
+        with requires_application_context(
+            requires_application_context.on.relation_broken(airflow_api_server_requires_relation),
+            requires_application_state,
+        ) as manager:
             state_out = manager.run()
 
             assert (

--- a/charms/api-server/tests/scenario/test_airflow_api_server.py
+++ b/charms/api-server/tests/scenario/test_airflow_api_server.py
@@ -1,0 +1,225 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import dataclasses
+import logging
+
+import ops
+import ops.testing
+import pytest
+from charms.airflow_api_server_k8s.v0.airflow_api_server import AirflowAPIServerProvides, AirflowAPIServerRequires
+
+import constants
+
+logger = logging.getLogger(__name__)
+
+
+class AirflowAPIServerMockCharm(ops.CharmBase):
+    """Mock Airflow API Server charm."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self.provides = AirflowAPIServerProvides(
+            self,
+            constants.AIRFLOW_API_SERVER_RELATION_ENDPOINT,
+            "test-host",
+            "test-port",
+        )
+
+        self.unit.status = ops.ActiveStatus()
+
+
+class AirflowAPIServerRequirerMockCharm(ops.CharmBase):
+    """Mock charm that requires the airflow-api-server relation."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self.requires = AirflowAPIServerRequires(
+            self,
+            constants.AIRFLOW_API_SERVER_RELATION_ENDPOINT,
+            self.reconcile,
+        )
+
+        self.unit.status = ops.BlockedStatus()
+
+    def reconcile(self, event) -> None:
+        logger.info(f"§Requirer reacting to event: {type(event)}")
+
+        self.unit.status = ops.ActiveStatus()
+
+
+@pytest.fixture(scope="function")
+def provides_application_context():
+    return ops.testing.Context(
+        charm_type=AirflowAPIServerMockCharm,
+        meta={
+            "name": "airflow-api-server",
+            "provides": {
+                constants.AIRFLOW_API_SERVER_RELATION_ENDPOINT: {
+                    "interface": "airflow_api_server",
+                    "limit": 1,
+                },
+            },
+        },
+    )
+
+
+@pytest.fixture(scope="function")
+def requires_application_context():
+    return ops.testing.Context(
+        charm_type=AirflowAPIServerRequirerMockCharm,
+        meta={
+            "name": "mock-airflow-api-server-requirer",
+            "requires": {
+                constants.AIRFLOW_API_SERVER_RELATION_ENDPOINT: {
+                    "interface": "airflow_api_server",
+                    "limit": 1,
+                },
+            },
+        },
+    )
+
+
+@pytest.fixture(scope="function")
+def airflow_application_provides_relation():
+    return ops.testing.Relation(
+        constants.AIRFLOW_API_SERVER_RELATION_ENDPOINT,
+        interface="airflow_api_server",
+    )
+
+
+@pytest.fixture(scope="function")
+def airflow_api_server_requires_relation():
+    return ops.testing.Relation(
+        constants.AIRFLOW_API_SERVER_RELATION_ENDPOINT,
+        interface="airflow_api_server",
+        remote_app_data={
+            "host": "test-receiving-host",
+            "port": "test-receiving-port",
+        },
+    )
+
+
+@pytest.fixture(scope="function")
+def provides_application_state(airflow_application_provides_relation):
+    return ops.testing.State(
+        leader=True,
+        relations=[airflow_application_provides_relation],
+    )
+
+
+@pytest.fixture(scope="function")
+def requires_application_state(airflow_api_server_requires_relation):
+    return ops.testing.State(
+        leader=True,
+        relations=[airflow_api_server_requires_relation],
+    )
+
+class TestAirflowAPIServerProvides:
+    def test_missing_relation(self, provides_application_context, provides_application_state):
+        provides_application_state = dataclasses.replace(provides_application_state, relations=[])
+
+        state_out = provides_application_context.run(
+            provides_application_context.on.start(), provides_application_state
+        )
+        assert state_out.unit_status == ops.ActiveStatus()
+
+    def test_non_leader_noop(self, provides_application_context, provides_application_state):
+        provides_application_state = dataclasses.replace(provides_application_state, leader=False)
+
+        state_out = provides_application_context.run(
+            provides_application_context.on.start(), provides_application_state
+        )
+
+        assert state_out.unit_status == ops.ActiveStatus()
+        assert (
+            state_out.get_relations(constants.AIRFLOW_API_SERVER_RELATION_ENDPOINT)[
+                0
+            ].local_app_data
+            == {}
+        )
+
+    def test_successful_set_of_data(
+        self, provides_application_context, provides_application_state
+    ):
+        state_out = provides_application_context.run(
+            provides_application_context.on.start(), provides_application_state
+        )
+
+        assert state_out.unit_status == ops.ActiveStatus()
+        assert sorted(
+            state_out.get_relations(constants.AIRFLOW_API_SERVER_RELATION_ENDPOINT)[
+                0
+            ].local_app_data
+        ) == sorted(
+            {
+                "host": "test-host",
+                "port": "test-port",
+            }
+        )
+
+
+class TestAirflowAPIServerRequires:
+    def get_juju_log_line(self, log_level: str, event: ops.EventBase):
+        return ops.testing.JujuLogLine(
+            level=log_level, message=f"§Requirer reacting to event: {event}"
+        )
+
+    def test_missing_relation(self, requires_application_context, requires_application_state):
+        requires_application_state = dataclasses.replace(requires_application_state, relations=[])
+
+        with requires_application_context(requires_application_context.on.start(), requires_application_state) as manager:
+            state_out = manager.run()
+
+            assert (
+                self.get_juju_log_line("INFO", ops.StartEvent)
+                not in requires_application_context.juju_log
+            )
+
+            assert state_out.unit_status == ops.BlockedStatus()
+            assert manager.charm.requires.api_server_host is None
+            assert manager.charm.requires.api_server_port is None
+
+    def test_valid_relation(self, requires_application_context, requires_application_state, airflow_api_server_requires_relation):
+        with requires_application_context(requires_application_context.on.relation_changed(airflow_api_server_requires_relation), requires_application_state) as manager:
+            state_out = manager.run()
+
+            assert (
+                self.get_juju_log_line("INFO", ops.RelationChangedEvent)
+                in requires_application_context.juju_log
+            )
+
+            assert state_out.unit_status == ops.ActiveStatus()
+            assert manager.charm.requires.api_server_host == "test-receiving-host"
+            assert manager.charm.requires.api_server_port == "test-receiving-port"
+
+        updated_relation = dataclasses.replace(airflow_api_server_requires_relation, remote_app_data={"host": "updated-receiving-host", "port": "updated-receiving-port"})
+        updated_state = dataclasses.replace(state_out, relations=[updated_relation])
+        updated_state = dataclasses.replace(updated_state, unit_status=ops.WaitingStatus())
+
+        with requires_application_context(requires_application_context.on.relation_changed(updated_relation), updated_state) as manager:
+            state_out = manager.run()
+
+            assert (
+                self.get_juju_log_line("INFO", ops.RelationChangedEvent)
+                in requires_application_context.juju_log
+            )
+
+            assert state_out.unit_status == ops.ActiveStatus()
+            assert manager.charm.requires.api_server_host == "updated-receiving-host"
+            assert manager.charm.requires.api_server_port == "updated-receiving-port"
+
+    def test_relation_break(self, requires_application_context, requires_application_state, airflow_api_server_requires_relation):
+        with requires_application_context(requires_application_context.on.relation_broken(airflow_api_server_requires_relation), requires_application_state) as manager:
+            state_out = manager.run()
+
+            assert (
+                self.get_juju_log_line("INFO", ops.RelationBrokenEvent)
+                in requires_application_context.juju_log
+            )
+
+            assert state_out.unit_status == ops.ActiveStatus()
+            assert manager.charm.requires.api_server_host is None
+            assert manager.charm.requires.api_server_port is None

--- a/charms/api-server/tests/scenario/test_charm.py
+++ b/charms/api-server/tests/scenario/test_charm.py
@@ -1,3 +1,6 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import dataclasses
 import unittest.mock
 
@@ -21,7 +24,7 @@ def test_missing_relation_status_scenario(context, state, container):
     state_in = dataclasses.replace(state, relations=[])
 
     with (
-        unittest.mock.patch("ops.model.Container.stop",autospec=True),
+        unittest.mock.patch("ops.model.Container.stop", autospec=True),
         unittest.mock.patch("ops.model.Container.exists", autospec=True, return_value=False),
     ):
         state_out = context.run(context.on.pebble_ready(container), state_in)
@@ -30,6 +33,7 @@ def test_missing_relation_status_scenario(context, state, container):
 
     out_container = state_out.get_container(constants.CONTAINER_NAME)
     assert "api-server-base" not in out_container.layers
+
 
 def test_missing_relation_with_cleanup_config_exists_scenario(context, state, container):
     """Missing relation; stop succeeds; config exists.
@@ -58,6 +62,7 @@ def test_missing_relation_with_cleanup_config_exists_scenario(context, state, co
     out_container = state_out.get_container(constants.CONTAINER_NAME)
     assert "api-server-base" not in out_container.layers
 
+
 def test_stop_service_pebble_api_error_scenario(context, state, container):
     """When relation is missing and stopping the service raises Pebble APIError.
 
@@ -79,9 +84,7 @@ def test_stop_service_pebble_api_error_scenario(context, state, container):
     ):
         state_out = context.run(context.on.pebble_ready(container), state_in)
 
-    assert state_out.unit_status == ops.BlockedStatus(
-        "Failed to stop pebble service"
-    )
+    assert state_out.unit_status == ops.BlockedStatus("Failed to stop pebble service")
 
     out_container = state_out.get_container(constants.CONTAINER_NAME)
     assert "api-server-base" not in out_container.layers
@@ -102,9 +105,7 @@ def test_waiting_when_cannot_write_airflow_config(context, state, container, api
     ):
         state_out = context.run(context.on.pebble_ready(container), state_in)
 
-    assert state_out.unit_status == ops.WaitingStatus(
-        "Waiting for relation data from coordinator"
-    )
+    assert state_out.unit_status == ops.WaitingStatus("Waiting for relation data from coordinator")
 
     out_container = state_out.get_container(constants.CONTAINER_NAME)
     assert "api-server-base" not in out_container.layers

--- a/charms/api-server/tox.ini
+++ b/charms/api-server/tox.ini
@@ -10,7 +10,7 @@ min_version = 4.0.0
 [vars]
 src_path = {tox_root}/src
 tests_path = {tox_root}/tests
-lib_path = {tox_root}/lib/charms/airflow_coordinator_k8s
+lib_path = {tox_root}/lib/charms/airflow_api_server_k8s
 all_path = {[vars]src_path} {[vars]tests_path} {[vars]lib_path}
 uv_flags = --isolated
 

--- a/charms/dag-processor/tox.ini
+++ b/charms/dag-processor/tox.ini
@@ -10,8 +10,7 @@ min_version = 4.0.0
 [vars]
 src_path = {tox_root}/src
 tests_path = {tox_root}/tests
-lib_path = {tox_root}/lib/charms/airflow_coordinator_k8s
-all_path = {[vars]src_path} {[vars]tests_path} {[vars]lib_path}
+all_path = {[vars]src_path} {[vars]tests_path}
 uv_flags = --isolated
 
 [testenv]
@@ -57,7 +56,7 @@ allowlist_externals =
 commands =
     uv sync --active --group unit
     uv run coverage run \
-        --source={[vars]src_path} --source={[vars]lib_path} --module pytest \
+        --source={[vars]src_path} --module pytest \
         {[vars]tests_path}/scenario \
         {posargs}
     uv tool run {[vars]uv_flags} coverage report

--- a/charms/scheduler/tox.ini
+++ b/charms/scheduler/tox.ini
@@ -10,8 +10,7 @@ min_version = 4.0.0
 [vars]
 src_path = {tox_root}/src
 tests_path = {tox_root}/tests
-lib_path = {tox_root}/lib/charms/airflow_coordinator_k8s
-all_path = {[vars]src_path} {[vars]tests_path} {[vars]lib_path}
+all_path = {[vars]src_path} {[vars]tests_path}
 uv_flags = --isolated
 
 [testenv]

--- a/charms/triggerer/tox.ini
+++ b/charms/triggerer/tox.ini
@@ -10,8 +10,7 @@ min_version = 4.0.0
 [vars]
 src_path = {tox_root}/src
 tests_path = {tox_root}/tests
-lib_path = {tox_root}/lib/charms/airflow_coordinator_k8s
-all_path = {[vars]src_path} {[vars]tests_path} {[vars]lib_path}
+all_path = {[vars]src_path} {[vars]tests_path}
 uv_flags = --isolated
 
 [testenv]
@@ -57,7 +56,7 @@ allowlist_externals =
 commands =
     uv sync --active --group unit
     uv run coverage run \
-        --source={[vars]src_path} --source={[vars]lib_path} --module pytest \
+        --source={[vars]src_path} --module pytest \
         {[vars]tests_path}/scenario \
         {posargs}
     uv tool run {[vars]uv_flags} coverage report

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -91,6 +91,11 @@ def deployed_stack(juju: jubilant.Juju, core_charms: dict):
         f"{constants.COORDINATOR_APP}:postgres", f"{constants.PGBOUNCER_APP}:database"
     )
 
+    juju.integrate(
+        f"{constants.COORDINATOR_APP}:airflow-api-server",
+        f"{constants.CORE_CHARMS['api-server']}:airflow-api-server",
+    )
+
     for _, app in constants.CORE_CHARMS.items():
         juju.integrate(
             f"{constants.COORDINATOR_APP}:{constants.COORD_REL}",

--- a/tests/integration/test_functional.py
+++ b/tests/integration/test_functional.py
@@ -12,7 +12,7 @@ import pytest
 import jubilant
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 
-from tests.integration.conftest import pebble_service_is_running
+from tests.integration.conftest import pebble_service_is_running, get_pebble_service_status
 from tests.integration.helpers.airflow_helpers import (
     json_from_airflow,
     read_airflow_config,
@@ -90,20 +90,34 @@ def test_config_change_propagates_and_dags_reserialize(
         juju, f"{constants.COORDINATOR_APP}/0", "load_examples", True
     )
 
-    # TODO: Update once the issue https://github.com/canonical/airflow-core-operators/issues/19 is resolved
+    # Stop all components to ensure conflictless singular dag reserialization
     for component, app in constants.CORE_CHARMS.items():
         juju.ssh(
             f"{app}/0",
-            "pebble restart airflow",
+            "pebble stop airflow",
             container=constants.CONTAINER_NAMES[component],
         )
 
+        service_status = get_pebble_service_status(juju, component, f"{app}/0", "airflow")
+        assert service_status["current"] == "inactive", f"Issue stopping service for {component}"
+
+    juju.ssh(
+        f"{constants.CORE_CHARMS['dag-processor']}/0",
+        "bash -lc " + shlex.quote("airflow dags reserialize"),
+        container=constants.CONTAINER_NAMES["dag-processor"],
+    )
+
+    # Start all components after dag reserialization
     for component, app in constants.CORE_CHARMS.items():
         juju.ssh(
             f"{app}/0",
-            "bash -lc " + shlex.quote("airflow dags reserialize"),
+            "pebble start airflow",
             container=constants.CONTAINER_NAMES[component],
         )
+
+        service_status = get_pebble_service_status(juju, component, f"{app}/0", "airflow")
+        assert service_status["current"] == "active", f"Issue starting service for {component}"
+
 
     for component, app in constants.CORE_CHARMS.items():
         cfg = read_airflow_config(
@@ -170,7 +184,7 @@ def test_scheduler_scale_and_resilience(
             )
 
             for attempt in Retrying(
-                stop=stop_after_attempt(6), wait=wait_fixed(10), reraise=True
+                stop=stop_after_attempt(6), wait=wait_fixed(30), reraise=True
             ):
                 with attempt:
                     out = juju.ssh(
@@ -183,14 +197,17 @@ def test_scheduler_scale_and_resilience(
                         container=constants.CONTAINER_NAMES["scheduler"],
                     )
                     runs = json_from_airflow(out)
+                    # TODO: remove "failed" from accepted run state after
+                    # https://github.com/canonical/airflow-core-operators/issues/17
+                    # resolved, i.e. we can reliably ensure successful runs
                     if not any(
                         run.get("run_id") == run_id
-                        and run.get("state") in {"queued", "running"}
+                        and run.get("state") in {"queued", "running", "failed", "success"}
                         for run in runs
                         if isinstance(runs, list)
                     ):
                         raise AssertionError(
-                            f"DAG run {run_id} did not reach queued/running"
+                            f"DAG run {run_id} did not get queued or begin execution"
                         )
     finally:
         juju.remove_unit(constants.CORE_CHARMS["scheduler"], num_units=2)


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Adds a `provides` relation endpoint for `airflow_api_server` interface to API server charm (with a hardcoded k8s endpoint FQDN for API server host)
Adds charm lib for both Requires and Provides of this relation interface
Adds in unit tests for this charm lib
Removes incorrect inclusion of airflow coordinator lib in coverage of unit tests 

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->
There will be an associated PR in the Airflow Coordinator repo that imports the charm lib in this PR and integrates with the proposed relation.

After this PR and above mentioned coordinator PR are merged, we will open a PR in this repo to remove workarounds in the shared integration tests (that require update of `base_url` for correct API server access) 

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
