### PR TITLE
[WF-329] Add publish-libs job to CI workflow publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,3 +96,20 @@ jobs:
           channel: 3.1/edge
           tag-prefix: ${{ steps.meta.outputs.tag_prefix }}
           charmcraft-channel: 3.x/stable
+
+  publish-libs:
+    name: Publish charm libs
+    needs: [get-modified-charms, run-tests]
+    if: ${{ needs.get-modified-charms.outputs.paths != '[]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Upload charm libs
+        uses: canonical/charming-actions/release-libraries@2.6.2
+        with:
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          charmcraft-channel: 3.x/stable

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -98,11 +98,15 @@ jobs:
           charmcraft-channel: 3.x/stable
 
   publish-libs:
-    name: Publish charm libs
+    name: Publish charm libs (${{ matrix.charm_path }})
     needs: [get-modified-charms, run-tests]
     if: ${{ needs.get-modified-charms.outputs.paths != '[]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        charm_path: ${{ fromJSON(needs.get-modified-charms.outputs.paths) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -112,4 +116,5 @@ jobs:
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          charm-path: ${{ matrix.charm_path }}
           charmcraft-channel: 3.x/stable


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
`publish-libs` github action is used to publish newly created/ updated libs in this repo as and when changes are made.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
