### PR TITLE
[WF-335] Update airflow-coordinator charm lib and persist TLS CA chains for s3 connections

### DIFF
--- a/charms/api-server/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/api-server/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -165,7 +165,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 logger = logging.getLogger(__name__)
@@ -265,12 +265,19 @@ SensitiveDataSecretStr = typing.Annotated[
 class AirflowCoordinatorProviderModel(data_interfaces.BaseCommonModel):
     """Provider side of the Airflow Coordinator model."""
 
-    config_template: str | None = pydantic.Field(default=None)
-    kubernetes_executor_pod_spec: str | None = pydantic.Field(default=None)
-    sensitive_data: SensitiveDataSecretStr = pydantic.Field(default=None)
-    secret_sensitive_data: data_interfaces.SecretString = pydantic.Field(default=None)
+    # FIXME: config_template accepts str | dict to support both Jinja2 templates
+    # (str from coordinator) and structured config dicts (from executor, deserialized
+    # by data_interfaces' get_data). This will change when we refactor the library
+    # to a much more generic one.
+    config_template: str | dict | None = None
+    kubernetes_executor_pod_spec: str | None = None
+    sensitive_data: SensitiveDataSecretStr = None
+    secret_sensitive_data: data_interfaces.SecretString | None = None
 
-    validation_failures: str | None = pydantic.Field(default=None)
+    validation_failures: str | None = None
+
+    # CA chains for Airflow connections
+    tls_ca_chains: dict[str, str] | None = None
 
     # hack to enable databag diff computation with data_interfaces v1 charm lib
     request_id: str = pydantic.Field(default="fixed_request_id", exclude=True)
@@ -543,7 +550,8 @@ class AirflowCoordinatorRequirerEventHandler(
             return self.interface.build_model(
                 self.relation.id, AirflowCoordinatorProviderModel, component=self.relation.app
             )
-        except pydantic.ValidationError:
+        except pydantic.ValidationError as e:
+            logger.error("VALIDATION ERROR: %s", e)
             return None
 
     @property
@@ -652,6 +660,7 @@ class AirflowCoordinatorProviderEventHandler(
         config_template: str = None,
         kubernetes_executor_pod_spec: str = None,
         sensitive_data: dict[str, str] = {},
+        tls_ca_chains: dict[str, str] = {},
     ):
         """Update data to send to related core charms."""
         if not self.interface.relations:
@@ -675,11 +684,12 @@ class AirflowCoordinatorProviderEventHandler(
                     if config_template:
                         model.config_template = config_template
 
-                    if kubernetes_executor_pod_spec:
-                        model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
+                    model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
 
                     if sensitive_data:
                         model.sensitive_data = json.dumps(sensitive_data)
+
+                    model.tls_ca_chains = tls_ca_chains
 
                     model.validation_failures = None
                 except pydantic.ValidationError:
@@ -690,6 +700,7 @@ class AirflowCoordinatorProviderEventHandler(
                     config_template=config_template,
                     kubernetes_executor_pod_spec=kubernetes_executor_pod_spec,
                     sensitive_data=json.dumps(sensitive_data),
+                    tls_ca_chains=tls_ca_chains,
                 )
 
             self.interface.write_model(relation.id, model)
@@ -995,6 +1006,28 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
             make_dirs=True,
         )
 
+    @property
+    def can_write_tls_ca_chain(self) -> bool:
+        """Indicate if there exist tls ca chains to write to workload container.
+
+        Ensures lack of validation errors + pebble is reachable in the workload
+        container + tls ca chains present in the relation.
+        """
+        return (
+            self._workload_container.can_connect()
+            and self._ready
+            and self._requirer_handler.provider_content.tls_ca_chains
+        )
+
+    def write_tls_ca_chains(self, user: str, group: str) -> None:
+        """Write available TLS CA chains to the workload container."""
+        provider_content = self._requirer_handler.provider_content
+
+        for filename, tls_ca_chain in provider_content.tls_ca_chains.items():
+            self._workload_container.push(
+                filename, tls_ca_chain, user=user, group=group, make_dirs=True
+            )
+
 
 class AirflowCoordinatorProvides(ops.Object):
     """A provider handler encapsulating the airflow coordinator relation."""
@@ -1137,6 +1170,7 @@ class AirflowCoordinatorProvides(ops.Object):
         config_template: typing.Optional[str] = None,
         k8s_executor_pod_spec_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
+        tls_ca_chains: dict[str, str] = {},
     ) -> None:
         """Update config with related core charms.
 
@@ -1145,9 +1179,11 @@ class AirflowCoordinatorProvides(ops.Object):
             k8s_executor_pod_spec_template: (optional) K8s executor pod spec template.
             sensitive_data: sensitive data to render config of k8s executor pod
                 spec jinja templates with.
+            tls_ca_chains: mapping from filename to tls ca chain file contents
         """
         self._provider_handler.update_content(
             config_template=config_template,
             kubernetes_executor_pod_spec=k8s_executor_pod_spec_template,
             sensitive_data=sensitive_data,
+            tls_ca_chains=tls_ca_chains,
         )

--- a/charms/api-server/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/api-server/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -1024,9 +1024,16 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         provider_content = self._requirer_handler.provider_content
 
         for filename, tls_ca_chain in provider_content.tls_ca_chains.items():
-            self._workload_container.push(
-                filename, tls_ca_chain, user=user, group=group, make_dirs=True
+            on_disk_tls_ca_chain = (
+                self._workload_container.pull(filename).read()
+                if self._workload_container.exists(filename)
+                else None
             )
+
+            if on_disk_tls_ca_chain != tls_ca_chain:
+                self._workload_container.push(
+                    filename, tls_ca_chain, user=user, group=group, make_dirs=True
+                )
 
 
 class AirflowCoordinatorProvides(ops.Object):

--- a/charms/api-server/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/api-server/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -165,7 +165,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -1020,7 +1020,16 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         )
 
     def write_tls_ca_chains(self, user: str, group: str) -> None:
-        """Write available TLS CA chains to the workload container."""
+        """Write available TLS CA chains to the workload container.
+
+        The TLS CA chains are written to a preset filepath (based on the
+        filepath encoded in the Airflow connection). This filepath is included
+        in the information retrieved from the relation databag.
+
+        This method only writes contents to the workload container if there is
+        a difference between existing file contents and file contents specified
+        in the relation databag.
+        """
         provider_content = self._requirer_handler.provider_content
 
         for filename, tls_ca_chain in provider_content.tls_ca_chains.items():

--- a/charms/api-server/src/charm.py
+++ b/charms/api-server/src/charm.py
@@ -184,7 +184,9 @@ class AirflowApiServerCharm(ops.CharmBase):
                 self._write_airflow_config(config_path=constants.AIRFLOW_CONFIG_PATH)
 
             if self._config_requires.can_write_tls_ca_chain:
-                self._config_requires.write_tls_ca_chains(constants.WORKLOAD_USER, constants.WORKLOAD_GROUP)
+                self._config_requires.write_tls_ca_chains(
+                    constants.WORKLOAD_USER, constants.WORKLOAD_GROUP
+                )
 
             self._add_layer_and_replan(restart_service=airflow_config_updated)
         except ExitWithStatusError as e:

--- a/charms/api-server/src/charm.py
+++ b/charms/api-server/src/charm.py
@@ -170,16 +170,22 @@ class AirflowApiServerCharm(ops.CharmBase):
         try:
             self._check_pebble_connection()
             self._check_required_relations()
+
             if not self._config_requires.can_write_airflow_config:
                 raise ExitWithStatusError(
                     "Waiting for relation data from coordinator",
                     ops.WaitingStatus,
                 )
+
             airflow_config_updated = self._config_requires.airflow_config_needs_update(
                 config_path=constants.AIRFLOW_CONFIG_PATH
             )
             if airflow_config_updated:
                 self._write_airflow_config(config_path=constants.AIRFLOW_CONFIG_PATH)
+
+            if self._config_requires.can_write_tls_ca_chain:
+                self._config_requires.write_tls_ca_chains(constants.WORKLOAD_USER, constants.WORKLOAD_GROUP)
+
             self._add_layer_and_replan(restart_service=airflow_config_updated)
         except ExitWithStatusError as e:
             self.unit.status = e.status

--- a/charms/dag-processor/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/dag-processor/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -165,7 +165,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 logger = logging.getLogger(__name__)
@@ -265,12 +265,19 @@ SensitiveDataSecretStr = typing.Annotated[
 class AirflowCoordinatorProviderModel(data_interfaces.BaseCommonModel):
     """Provider side of the Airflow Coordinator model."""
 
-    config_template: str | None = pydantic.Field(default=None)
-    kubernetes_executor_pod_spec: str | None = pydantic.Field(default=None)
-    sensitive_data: SensitiveDataSecretStr = pydantic.Field(default=None)
-    secret_sensitive_data: data_interfaces.SecretString = pydantic.Field(default=None)
+    # FIXME: config_template accepts str | dict to support both Jinja2 templates
+    # (str from coordinator) and structured config dicts (from executor, deserialized
+    # by data_interfaces' get_data). This will change when we refactor the library
+    # to a much more generic one.
+    config_template: str | dict | None = None
+    kubernetes_executor_pod_spec: str | None = None
+    sensitive_data: SensitiveDataSecretStr = None
+    secret_sensitive_data: data_interfaces.SecretString | None = None
 
-    validation_failures: str | None = pydantic.Field(default=None)
+    validation_failures: str | None = None
+
+    # CA chains for Airflow connections
+    tls_ca_chains: dict[str, str] | None = None
 
     # hack to enable databag diff computation with data_interfaces v1 charm lib
     request_id: str = pydantic.Field(default="fixed_request_id", exclude=True)
@@ -543,7 +550,8 @@ class AirflowCoordinatorRequirerEventHandler(
             return self.interface.build_model(
                 self.relation.id, AirflowCoordinatorProviderModel, component=self.relation.app
             )
-        except pydantic.ValidationError:
+        except pydantic.ValidationError as e:
+            logger.error("VALIDATION ERROR: %s", e)
             return None
 
     @property
@@ -652,6 +660,7 @@ class AirflowCoordinatorProviderEventHandler(
         config_template: str = None,
         kubernetes_executor_pod_spec: str = None,
         sensitive_data: dict[str, str] = {},
+        tls_ca_chains: dict[str, str] = {},
     ):
         """Update data to send to related core charms."""
         if not self.interface.relations:
@@ -675,11 +684,12 @@ class AirflowCoordinatorProviderEventHandler(
                     if config_template:
                         model.config_template = config_template
 
-                    if kubernetes_executor_pod_spec:
-                        model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
+                    model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
 
                     if sensitive_data:
                         model.sensitive_data = json.dumps(sensitive_data)
+
+                    model.tls_ca_chains = tls_ca_chains
 
                     model.validation_failures = None
                 except pydantic.ValidationError:
@@ -690,6 +700,7 @@ class AirflowCoordinatorProviderEventHandler(
                     config_template=config_template,
                     kubernetes_executor_pod_spec=kubernetes_executor_pod_spec,
                     sensitive_data=json.dumps(sensitive_data),
+                    tls_ca_chains=tls_ca_chains,
                 )
 
             self.interface.write_model(relation.id, model)
@@ -995,6 +1006,28 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
             make_dirs=True,
         )
 
+    @property
+    def can_write_tls_ca_chain(self) -> bool:
+        """Indicate if there exist tls ca chains to write to workload container.
+
+        Ensures lack of validation errors + pebble is reachable in the workload
+        container + tls ca chains present in the relation.
+        """
+        return (
+            self._workload_container.can_connect()
+            and self._ready
+            and self._requirer_handler.provider_content.tls_ca_chains
+        )
+
+    def write_tls_ca_chains(self, user: str, group: str) -> None:
+        """Write available TLS CA chains to the workload container."""
+        provider_content = self._requirer_handler.provider_content
+
+        for filename, tls_ca_chain in provider_content.tls_ca_chains.items():
+            self._workload_container.push(
+                filename, tls_ca_chain, user=user, group=group, make_dirs=True
+            )
+
 
 class AirflowCoordinatorProvides(ops.Object):
     """A provider handler encapsulating the airflow coordinator relation."""
@@ -1137,6 +1170,7 @@ class AirflowCoordinatorProvides(ops.Object):
         config_template: typing.Optional[str] = None,
         k8s_executor_pod_spec_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
+        tls_ca_chains: dict[str, str] = {},
     ) -> None:
         """Update config with related core charms.
 
@@ -1145,9 +1179,11 @@ class AirflowCoordinatorProvides(ops.Object):
             k8s_executor_pod_spec_template: (optional) K8s executor pod spec template.
             sensitive_data: sensitive data to render config of k8s executor pod
                 spec jinja templates with.
+            tls_ca_chains: mapping from filename to tls ca chain file contents
         """
         self._provider_handler.update_content(
             config_template=config_template,
             kubernetes_executor_pod_spec=k8s_executor_pod_spec_template,
             sensitive_data=sensitive_data,
+            tls_ca_chains=tls_ca_chains,
         )

--- a/charms/dag-processor/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/dag-processor/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -1024,9 +1024,16 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         provider_content = self._requirer_handler.provider_content
 
         for filename, tls_ca_chain in provider_content.tls_ca_chains.items():
-            self._workload_container.push(
-                filename, tls_ca_chain, user=user, group=group, make_dirs=True
+            on_disk_tls_ca_chain = (
+                self._workload_container.pull(filename).read()
+                if self._workload_container.exists(filename)
+                else None
             )
+
+            if on_disk_tls_ca_chain != tls_ca_chain:
+                self._workload_container.push(
+                    filename, tls_ca_chain, user=user, group=group, make_dirs=True
+                )
 
 
 class AirflowCoordinatorProvides(ops.Object):

--- a/charms/dag-processor/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/dag-processor/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -165,7 +165,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -1020,7 +1020,16 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         )
 
     def write_tls_ca_chains(self, user: str, group: str) -> None:
-        """Write available TLS CA chains to the workload container."""
+        """Write available TLS CA chains to the workload container.
+
+        The TLS CA chains are written to a preset filepath (based on the
+        filepath encoded in the Airflow connection). This filepath is included
+        in the information retrieved from the relation databag.
+
+        This method only writes contents to the workload container if there is
+        a difference between existing file contents and file contents specified
+        in the relation databag.
+        """
         provider_content = self._requirer_handler.provider_content
 
         for filename, tls_ca_chain in provider_content.tls_ca_chains.items():

--- a/charms/dag-processor/src/charm.py
+++ b/charms/dag-processor/src/charm.py
@@ -150,17 +150,23 @@ class AirflowDagProcessorCharm(ops.CharmBase):
         try:
             self._check_pebble_connection()
             self._check_required_relations()
+
             if not self._config_requires.can_write_airflow_config:
                 raise ExitWithStatusError(
                     "Waiting for relation data from coordinator",
                     ops.WaitingStatus,
                 )
-            restart_service = self._config_requires.airflow_config_needs_update(
+
+            airflow_config_updated = self._config_requires.airflow_config_needs_update(
                 config_path=constants.AIRFLOW_CONFIG_PATH
             )
-            if restart_service:
+            if airflow_config_updated:
                 self._write_airflow_config(config_path=constants.AIRFLOW_CONFIG_PATH)
-            self._add_layer_and_replan(restart_service=restart_service)
+
+            if self._config_requires.can_write_tls_ca_chain:
+                self._config_requires.write_tls_ca_chains(constants.WORKLOAD_USER, constants.WORKLOAD_GROUP)
+
+            self._add_layer_and_replan(restart_service=airflow_config_updated)
         except ExitWithStatusError as e:
             self.unit.status = e.status
             return

--- a/charms/dag-processor/src/charm.py
+++ b/charms/dag-processor/src/charm.py
@@ -164,7 +164,9 @@ class AirflowDagProcessorCharm(ops.CharmBase):
                 self._write_airflow_config(config_path=constants.AIRFLOW_CONFIG_PATH)
 
             if self._config_requires.can_write_tls_ca_chain:
-                self._config_requires.write_tls_ca_chains(constants.WORKLOAD_USER, constants.WORKLOAD_GROUP)
+                self._config_requires.write_tls_ca_chains(
+                    constants.WORKLOAD_USER, constants.WORKLOAD_GROUP
+                )
 
             self._add_layer_and_replan(restart_service=airflow_config_updated)
         except ExitWithStatusError as e:

--- a/charms/scheduler/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/scheduler/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -165,7 +165,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 logger = logging.getLogger(__name__)
@@ -265,12 +265,19 @@ SensitiveDataSecretStr = typing.Annotated[
 class AirflowCoordinatorProviderModel(data_interfaces.BaseCommonModel):
     """Provider side of the Airflow Coordinator model."""
 
-    config_template: str | None = pydantic.Field(default=None)
-    kubernetes_executor_pod_spec: str | None = pydantic.Field(default=None)
-    sensitive_data: SensitiveDataSecretStr = pydantic.Field(default=None)
-    secret_sensitive_data: data_interfaces.SecretString = pydantic.Field(default=None)
+    # FIXME: config_template accepts str | dict to support both Jinja2 templates
+    # (str from coordinator) and structured config dicts (from executor, deserialized
+    # by data_interfaces' get_data). This will change when we refactor the library
+    # to a much more generic one.
+    config_template: str | dict | None = None
+    kubernetes_executor_pod_spec: str | None = None
+    sensitive_data: SensitiveDataSecretStr = None
+    secret_sensitive_data: data_interfaces.SecretString | None = None
 
-    validation_failures: str | None = pydantic.Field(default=None)
+    validation_failures: str | None = None
+
+    # CA chains for Airflow connections
+    tls_ca_chains: dict[str, str] | None = None
 
     # hack to enable databag diff computation with data_interfaces v1 charm lib
     request_id: str = pydantic.Field(default="fixed_request_id", exclude=True)
@@ -543,7 +550,8 @@ class AirflowCoordinatorRequirerEventHandler(
             return self.interface.build_model(
                 self.relation.id, AirflowCoordinatorProviderModel, component=self.relation.app
             )
-        except pydantic.ValidationError:
+        except pydantic.ValidationError as e:
+            logger.error("VALIDATION ERROR: %s", e)
             return None
 
     @property
@@ -652,6 +660,7 @@ class AirflowCoordinatorProviderEventHandler(
         config_template: str = None,
         kubernetes_executor_pod_spec: str = None,
         sensitive_data: dict[str, str] = {},
+        tls_ca_chains: dict[str, str] = {},
     ):
         """Update data to send to related core charms."""
         if not self.interface.relations:
@@ -675,11 +684,12 @@ class AirflowCoordinatorProviderEventHandler(
                     if config_template:
                         model.config_template = config_template
 
-                    if kubernetes_executor_pod_spec:
-                        model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
+                    model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
 
                     if sensitive_data:
                         model.sensitive_data = json.dumps(sensitive_data)
+
+                    model.tls_ca_chains = tls_ca_chains
 
                     model.validation_failures = None
                 except pydantic.ValidationError:
@@ -690,6 +700,7 @@ class AirflowCoordinatorProviderEventHandler(
                     config_template=config_template,
                     kubernetes_executor_pod_spec=kubernetes_executor_pod_spec,
                     sensitive_data=json.dumps(sensitive_data),
+                    tls_ca_chains=tls_ca_chains,
                 )
 
             self.interface.write_model(relation.id, model)
@@ -995,6 +1006,28 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
             make_dirs=True,
         )
 
+    @property
+    def can_write_tls_ca_chain(self) -> bool:
+        """Indicate if there exist tls ca chains to write to workload container.
+
+        Ensures lack of validation errors + pebble is reachable in the workload
+        container + tls ca chains present in the relation.
+        """
+        return (
+            self._workload_container.can_connect()
+            and self._ready
+            and self._requirer_handler.provider_content.tls_ca_chains
+        )
+
+    def write_tls_ca_chains(self, user: str, group: str) -> None:
+        """Write available TLS CA chains to the workload container."""
+        provider_content = self._requirer_handler.provider_content
+
+        for filename, tls_ca_chain in provider_content.tls_ca_chains.items():
+            self._workload_container.push(
+                filename, tls_ca_chain, user=user, group=group, make_dirs=True
+            )
+
 
 class AirflowCoordinatorProvides(ops.Object):
     """A provider handler encapsulating the airflow coordinator relation."""
@@ -1137,6 +1170,7 @@ class AirflowCoordinatorProvides(ops.Object):
         config_template: typing.Optional[str] = None,
         k8s_executor_pod_spec_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
+        tls_ca_chains: dict[str, str] = {},
     ) -> None:
         """Update config with related core charms.
 
@@ -1145,9 +1179,11 @@ class AirflowCoordinatorProvides(ops.Object):
             k8s_executor_pod_spec_template: (optional) K8s executor pod spec template.
             sensitive_data: sensitive data to render config of k8s executor pod
                 spec jinja templates with.
+            tls_ca_chains: mapping from filename to tls ca chain file contents
         """
         self._provider_handler.update_content(
             config_template=config_template,
             kubernetes_executor_pod_spec=k8s_executor_pod_spec_template,
             sensitive_data=sensitive_data,
+            tls_ca_chains=tls_ca_chains,
         )

--- a/charms/scheduler/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/scheduler/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -1024,9 +1024,16 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         provider_content = self._requirer_handler.provider_content
 
         for filename, tls_ca_chain in provider_content.tls_ca_chains.items():
-            self._workload_container.push(
-                filename, tls_ca_chain, user=user, group=group, make_dirs=True
+            on_disk_tls_ca_chain = (
+                self._workload_container.pull(filename).read()
+                if self._workload_container.exists(filename)
+                else None
             )
+
+            if on_disk_tls_ca_chain != tls_ca_chain:
+                self._workload_container.push(
+                    filename, tls_ca_chain, user=user, group=group, make_dirs=True
+                )
 
 
 class AirflowCoordinatorProvides(ops.Object):

--- a/charms/scheduler/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/scheduler/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -165,7 +165,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -1020,7 +1020,16 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         )
 
     def write_tls_ca_chains(self, user: str, group: str) -> None:
-        """Write available TLS CA chains to the workload container."""
+        """Write available TLS CA chains to the workload container.
+
+        The TLS CA chains are written to a preset filepath (based on the
+        filepath encoded in the Airflow connection). This filepath is included
+        in the information retrieved from the relation databag.
+
+        This method only writes contents to the workload container if there is
+        a difference between existing file contents and file contents specified
+        in the relation databag.
+        """
         provider_content = self._requirer_handler.provider_content
 
         for filename, tls_ca_chain in provider_content.tls_ca_chains.items():

--- a/charms/scheduler/src/charm.py
+++ b/charms/scheduler/src/charm.py
@@ -125,7 +125,7 @@ class AirflowSchedulerCharm(ops.CharmBase):
         # Check if we can write the config
         # If not, the coordinator hasn't provided config yet (temporary condition)
         if not self._config_requires.can_write_airflow_config:
-            raise ExitWithStatusError("Waiting for relation data", ops.WaitingStatus)
+            raise ExitWithStatusError("Waiting for relation data from coordinator", ops.WaitingStatus)
 
         try:
             self._config_requires.write_airflow_config(

--- a/charms/scheduler/src/charm.py
+++ b/charms/scheduler/src/charm.py
@@ -43,7 +43,7 @@ class AirflowSchedulerCharm(ops.CharmBase):
         self._container = self.unit.get_container(constants.CONTAINER_NAME)
 
         # Create config requires object for handling Airflow configurations
-        self.config_requires = AirflowCoordinatorCoreRequires(
+        self._config_requires = AirflowCoordinatorCoreRequires(
             charm=self,
             relation_name=constants.AIRFLOW_COORDINATOR_RELATION_NAME,
             component=constants.AIRFLOW_COMPONENT,
@@ -124,11 +124,11 @@ class AirflowSchedulerCharm(ops.CharmBase):
         """
         # Check if we can write the config
         # If not, the coordinator hasn't provided config yet (temporary condition)
-        if not self.config_requires.can_write_airflow_config:
+        if not self._config_requires.can_write_airflow_config:
             raise ExitWithStatusError("Waiting for relation data", ops.WaitingStatus)
 
         try:
-            self.config_requires.write_airflow_config(
+            self._config_requires.write_airflow_config(
                 config_path=config_path,
                 user=constants.WORKLOAD_USER,
                 group=constants.WORKLOAD_GROUP,
@@ -155,7 +155,7 @@ class AirflowSchedulerCharm(ops.CharmBase):
         """
         # This means that the pod spec exists in the databag and
         # there are no issues writing it to the workload container
-        if self.config_requires.can_write_kubernetes_executor_pod_spec:
+        if self._config_requires.can_write_kubernetes_executor_pod_spec:
             return
 
         if self._container.exists(filepath):
@@ -182,12 +182,12 @@ class AirflowSchedulerCharm(ops.CharmBase):
         # FIXME: if the AirflowCoordinatorCoreRequires object had a way to access
         # the value of the k8s executor pod spec, we could improve this check to
         # correctly identify the reason why we cannot write the file.
-        if not self.config_requires.can_write_kubernetes_executor_pod_spec:
+        if not self._config_requires.can_write_kubernetes_executor_pod_spec:
             logger.info("The Kubernetes Executor pod spec file was not written.")
             return
 
         try:
-            self.config_requires.write_kubernetes_executor_pod_spec(
+            self._config_requires.write_kubernetes_executor_pod_spec(
                 filepath=filepath,
                 user=constants.WORKLOAD_USER,
                 group=constants.WORKLOAD_GROUP,
@@ -235,14 +235,20 @@ class AirflowSchedulerCharm(ops.CharmBase):
             self._check_container_can_connect()
             self._check_required_relation_and_act()
             self._write_kubernetes_executor_pod_spec()
-            if not self.config_requires.can_write_airflow_config:
+
+            if not self._config_requires.can_write_airflow_config:
                 raise ExitWithStatusError("Waiting for relation data", ops.WaitingStatus)
-            restart_service = self.config_requires.airflow_config_needs_update(
+
+            airflow_config_updated = self._config_requires.airflow_config_needs_update(
                 config_path=constants.AIRFLOW_CONFIG_PATH,
             )
-            if restart_service:
+            if airflow_config_updated:
                 self._write_airflow_config(config_path=constants.AIRFLOW_CONFIG_PATH)
-            self._add_layer_and_replan(restart_service=restart_service)
+
+            if self._config_requires.can_write_tls_ca_chain:
+                self._config_requires.write_tls_ca_chains(constants.WORKLOAD_USER, constants.WORKLOAD_GROUP)
+
+            self._add_layer_and_replan(restart_service=airflow_config_updated)
             self._remove_stale_kubernetes_executor_pod_spec()
         except ExitWithStatusError as e:
             self.unit.status = e.status

--- a/charms/scheduler/src/charm.py
+++ b/charms/scheduler/src/charm.py
@@ -125,7 +125,9 @@ class AirflowSchedulerCharm(ops.CharmBase):
         # Check if we can write the config
         # If not, the coordinator hasn't provided config yet (temporary condition)
         if not self._config_requires.can_write_airflow_config:
-            raise ExitWithStatusError("Waiting for relation data from coordinator", ops.WaitingStatus)
+            raise ExitWithStatusError(
+                "Waiting for relation data from coordinator", ops.WaitingStatus
+            )
 
         try:
             self._config_requires.write_airflow_config(

--- a/charms/scheduler/src/charm.py
+++ b/charms/scheduler/src/charm.py
@@ -246,7 +246,9 @@ class AirflowSchedulerCharm(ops.CharmBase):
                 self._write_airflow_config(config_path=constants.AIRFLOW_CONFIG_PATH)
 
             if self._config_requires.can_write_tls_ca_chain:
-                self._config_requires.write_tls_ca_chains(constants.WORKLOAD_USER, constants.WORKLOAD_GROUP)
+                self._config_requires.write_tls_ca_chains(
+                    constants.WORKLOAD_USER, constants.WORKLOAD_GROUP
+                )
 
             self._add_layer_and_replan(restart_service=airflow_config_updated)
             self._remove_stale_kubernetes_executor_pod_spec()

--- a/charms/scheduler/tests/scenario/test_charm.py
+++ b/charms/scheduler/tests/scenario/test_charm.py
@@ -276,9 +276,7 @@ def test_pod_spec_no_op_when_not_available_scenario(context, state, container, s
         unittest.mock.patch.object(
             AirflowCoordinatorCoreRequires, "write_kubernetes_executor_pod_spec"
         ) as write_pod_spec_mock,
-        unittest.mock.patch(
-            "ops.model.Container.exists", autospec=True, return_value=False
-        ),
+        unittest.mock.patch("ops.model.Container.exists", autospec=True, return_value=False),
         unittest.mock.patch("ops.model.Container.replan", autospec=True),
     ):
         state_out = context.run(context.on.pebble_ready(container), state_in)
@@ -316,12 +314,8 @@ def test_pod_spec_removed_when_not_in_databag_scenario(
         unittest.mock.patch.object(
             AirflowCoordinatorCoreRequires, "write_kubernetes_executor_pod_spec"
         ) as write_pod_spec_mock,
-        unittest.mock.patch(
-            "ops.model.Container.exists", autospec=True, return_value=True
-        ),
-        unittest.mock.patch(
-            "ops.model.Container.remove_path", autospec=True
-        ) as remove_mock,
+        unittest.mock.patch("ops.model.Container.exists", autospec=True, return_value=True),
+        unittest.mock.patch("ops.model.Container.remove_path", autospec=True) as remove_mock,
         unittest.mock.patch("ops.model.Container.replan", autospec=True),
     ):
         state_out = context.run(context.on.pebble_ready(container), state_in)

--- a/charms/triggerer/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/triggerer/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -165,7 +165,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 logger = logging.getLogger(__name__)
@@ -265,12 +265,19 @@ SensitiveDataSecretStr = typing.Annotated[
 class AirflowCoordinatorProviderModel(data_interfaces.BaseCommonModel):
     """Provider side of the Airflow Coordinator model."""
 
-    config_template: str | None = pydantic.Field(default=None)
-    kubernetes_executor_pod_spec: str | None = pydantic.Field(default=None)
-    sensitive_data: SensitiveDataSecretStr = pydantic.Field(default=None)
-    secret_sensitive_data: data_interfaces.SecretString = pydantic.Field(default=None)
+    # FIXME: config_template accepts str | dict to support both Jinja2 templates
+    # (str from coordinator) and structured config dicts (from executor, deserialized
+    # by data_interfaces' get_data). This will change when we refactor the library
+    # to a much more generic one.
+    config_template: str | dict | None = None
+    kubernetes_executor_pod_spec: str | None = None
+    sensitive_data: SensitiveDataSecretStr = None
+    secret_sensitive_data: data_interfaces.SecretString | None = None
 
-    validation_failures: str | None = pydantic.Field(default=None)
+    validation_failures: str | None = None
+
+    # CA chains for Airflow connections
+    tls_ca_chains: dict[str, str] | None = None
 
     # hack to enable databag diff computation with data_interfaces v1 charm lib
     request_id: str = pydantic.Field(default="fixed_request_id", exclude=True)
@@ -543,7 +550,8 @@ class AirflowCoordinatorRequirerEventHandler(
             return self.interface.build_model(
                 self.relation.id, AirflowCoordinatorProviderModel, component=self.relation.app
             )
-        except pydantic.ValidationError:
+        except pydantic.ValidationError as e:
+            logger.error("VALIDATION ERROR: %s", e)
             return None
 
     @property
@@ -652,6 +660,7 @@ class AirflowCoordinatorProviderEventHandler(
         config_template: str = None,
         kubernetes_executor_pod_spec: str = None,
         sensitive_data: dict[str, str] = {},
+        tls_ca_chains: dict[str, str] = {},
     ):
         """Update data to send to related core charms."""
         if not self.interface.relations:
@@ -675,11 +684,12 @@ class AirflowCoordinatorProviderEventHandler(
                     if config_template:
                         model.config_template = config_template
 
-                    if kubernetes_executor_pod_spec:
-                        model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
+                    model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
 
                     if sensitive_data:
                         model.sensitive_data = json.dumps(sensitive_data)
+
+                    model.tls_ca_chains = tls_ca_chains
 
                     model.validation_failures = None
                 except pydantic.ValidationError:
@@ -690,6 +700,7 @@ class AirflowCoordinatorProviderEventHandler(
                     config_template=config_template,
                     kubernetes_executor_pod_spec=kubernetes_executor_pod_spec,
                     sensitive_data=json.dumps(sensitive_data),
+                    tls_ca_chains=tls_ca_chains,
                 )
 
             self.interface.write_model(relation.id, model)
@@ -995,6 +1006,28 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
             make_dirs=True,
         )
 
+    @property
+    def can_write_tls_ca_chain(self) -> bool:
+        """Indicate if there exist tls ca chains to write to workload container.
+
+        Ensures lack of validation errors + pebble is reachable in the workload
+        container + tls ca chains present in the relation.
+        """
+        return (
+            self._workload_container.can_connect()
+            and self._ready
+            and self._requirer_handler.provider_content.tls_ca_chains
+        )
+
+    def write_tls_ca_chains(self, user: str, group: str) -> None:
+        """Write available TLS CA chains to the workload container."""
+        provider_content = self._requirer_handler.provider_content
+
+        for filename, tls_ca_chain in provider_content.tls_ca_chains.items():
+            self._workload_container.push(
+                filename, tls_ca_chain, user=user, group=group, make_dirs=True
+            )
+
 
 class AirflowCoordinatorProvides(ops.Object):
     """A provider handler encapsulating the airflow coordinator relation."""
@@ -1137,6 +1170,7 @@ class AirflowCoordinatorProvides(ops.Object):
         config_template: typing.Optional[str] = None,
         k8s_executor_pod_spec_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
+        tls_ca_chains: dict[str, str] = {},
     ) -> None:
         """Update config with related core charms.
 
@@ -1145,9 +1179,11 @@ class AirflowCoordinatorProvides(ops.Object):
             k8s_executor_pod_spec_template: (optional) K8s executor pod spec template.
             sensitive_data: sensitive data to render config of k8s executor pod
                 spec jinja templates with.
+            tls_ca_chains: mapping from filename to tls ca chain file contents
         """
         self._provider_handler.update_content(
             config_template=config_template,
             kubernetes_executor_pod_spec=k8s_executor_pod_spec_template,
             sensitive_data=sensitive_data,
+            tls_ca_chains=tls_ca_chains,
         )

--- a/charms/triggerer/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/triggerer/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -1024,9 +1024,16 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         provider_content = self._requirer_handler.provider_content
 
         for filename, tls_ca_chain in provider_content.tls_ca_chains.items():
-            self._workload_container.push(
-                filename, tls_ca_chain, user=user, group=group, make_dirs=True
+            on_disk_tls_ca_chain = (
+                self._workload_container.pull(filename).read()
+                if self._workload_container.exists(filename)
+                else None
             )
+
+            if on_disk_tls_ca_chain != tls_ca_chain:
+                self._workload_container.push(
+                    filename, tls_ca_chain, user=user, group=group, make_dirs=True
+                )
 
 
 class AirflowCoordinatorProvides(ops.Object):

--- a/charms/triggerer/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/triggerer/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -165,7 +165,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -1020,7 +1020,16 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         )
 
     def write_tls_ca_chains(self, user: str, group: str) -> None:
-        """Write available TLS CA chains to the workload container."""
+        """Write available TLS CA chains to the workload container.
+
+        The TLS CA chains are written to a preset filepath (based on the
+        filepath encoded in the Airflow connection). This filepath is included
+        in the information retrieved from the relation databag.
+
+        This method only writes contents to the workload container if there is
+        a difference between existing file contents and file contents specified
+        in the relation databag.
+        """
         provider_content = self._requirer_handler.provider_content
 
         for filename, tls_ca_chain in provider_content.tls_ca_chains.items():

--- a/charms/triggerer/src/charm.py
+++ b/charms/triggerer/src/charm.py
@@ -150,17 +150,23 @@ class AirflowTriggererCharm(ops.CharmBase):
         try:
             self._check_pebble_connection()
             self._check_required_relations()
+
             if not self._config_requires.can_write_airflow_config:
                 raise ExitWithStatusError(
                     "Waiting for relation data from coordinator",
                     ops.WaitingStatus,
                 )
-            restart_service = self._config_requires.airflow_config_needs_update(
+
+            airflow_config_updated = self._config_requires.airflow_config_needs_update(
                 config_path=constants.AIRFLOW_CONFIG_PATH
             )
-            if restart_service:
+            if airflow_config_updated:
                 self._write_airflow_config(config_path=constants.AIRFLOW_CONFIG_PATH)
-            self._add_layer_and_replan(restart_service=restart_service)
+
+            if self._config_requires.can_write_tls_ca_chain:
+                self._config_requires.write_tls_ca_chains(constants.WORKLOAD_USER, constants.WORKLOAD_GROUP)
+
+            self._add_layer_and_replan(restart_service=airflow_config_updated)
         except ExitWithStatusError as e:
             self.unit.status = e.status
             return

--- a/charms/triggerer/src/charm.py
+++ b/charms/triggerer/src/charm.py
@@ -164,7 +164,9 @@ class AirflowTriggererCharm(ops.CharmBase):
                 self._write_airflow_config(config_path=constants.AIRFLOW_CONFIG_PATH)
 
             if self._config_requires.can_write_tls_ca_chain:
-                self._config_requires.write_tls_ca_chains(constants.WORKLOAD_USER, constants.WORKLOAD_GROUP)
+                self._config_requires.write_tls_ca_chains(
+                    constants.WORKLOAD_USER, constants.WORKLOAD_GROUP
+                )
 
             self._add_layer_and_replan(restart_service=airflow_config_updated)
         except ExitWithStatusError as e:

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ clean-core-charms:
 integration *args: clean pack-charms
 	#!/usr/bin/bash
 	pdb_options=$(if [ -n "${debug}" ]; then echo "--pdb"; fi)
-	
+
 	export API_SERVER_CHARM_PATH=$(ls -t charms/api-server/*.charm | head -n1)
 	export DAG_PROCESSOR_CHARM_PATH=$(ls -t charms/dag-processor/*.charm | head -n1)
 	export SCHEDULER_CHARM_PATH=$(ls -t charms/scheduler/*.charm | head -n1)
@@ -37,12 +37,43 @@ clean: clean-core-charms
 	juju destroy-model --force --destroy-storage --no-prompt "${JUJU_MODEL:-test}" || true
 
 lint:
+	#!/usr/bin/bash
+	set -eux
+
 	uv sync --frozen --group lint
 	uv run tox -e lint
 
+	charms=("api-server" "dag-processor" "scheduler" "triggerer")
+
+	for charm in "${charms[@]}"; do
+		uv sync --frozen --group lint
+		cd ./charms/$charm && uv run tox -e lint && cd -
+	done
+
 format:
+	#!/usr/bin/bash
+	set -eux
+
 	uv sync --frozen --group format
 	uv run tox -e format
+
+	charms=("api-server" "dag-processor" "scheduler" "triggerer")
+
+	for charm in "${charms[@]}"; do
+		uv sync --frozen --group format
+		cd ./charms/$charm && uv run tox -e format && cd -
+	done
+
+# Run unit tests for all core charms
+unit:
+	#!/usr/bin/bash
+	set -eux
+
+	charms=("api-server" "dag-processor" "scheduler" "triggerer")
+
+	for charm in "${charms[@]}"; do
+		cd ./charms/$charm && uv run tox -e unit && cd -
+	done
 
 get-system-state:
 	#!/usr/bin/bash

--- a/tests/integration/test_charms.py
+++ b/tests/integration/test_charms.py
@@ -29,21 +29,27 @@ def test_pebble_services_and_config_exist(
 ):
     """Pebble services should be active and config should be present."""
 
-    for attempt in Retrying(stop=stop_after_attempt(6), wait=wait_fixed(30), reraise=True):
+    for attempt in Retrying(
+        stop=stop_after_attempt(6), wait=wait_fixed(30), reraise=True
+    ):
         with attempt:
             output = juju.ssh(
                 f"{app}/0",
                 f"test -f {shlex.quote(constants.AIRFLOW_CONFIG_PATH)} && echo OK || echo MISSING",
                 container=constants.CONTAINER_NAMES[component],
             )
-            assert "OK" in output, f"{app}: expected {constants.AIRFLOW_CONFIG_PATH} to exist"
+            assert "OK" in output, (
+                f"{app}: expected {constants.AIRFLOW_CONFIG_PATH} to exist"
+            )
 
             ownership = juju.ssh(
                 f"{app}/0",
                 f"stat -c '%U:%G' {shlex.quote(constants.AIRFLOW_CONFIG_PATH)}",
                 container=constants.CONTAINER_NAMES[component],
             ).strip()
-            assert ownership == f"{constants.WORKLOAD_USER}:{constants.WORKLOAD_GROUP}", (
+            assert (
+                ownership == f"{constants.WORKLOAD_USER}:{constants.WORKLOAD_GROUP}"
+            ), (
                 f"{app}: expected {constants.AIRFLOW_CONFIG_PATH} to be owned by "
                 f"{constants.WORKLOAD_USER}:{constants.WORKLOAD_GROUP}, got {ownership}"
             )

--- a/tests/integration/test_functional.py
+++ b/tests/integration/test_functional.py
@@ -78,6 +78,7 @@ def test_database_connectivity_from_scheduler(
     )
     assert "DB_CHECK_OK" in out, f"Failed to connect to the DB: {out}"
 
+
 def test_config_change_propagates_and_dags_reserialize(
     juju: jubilant.Juju,
 ):
@@ -193,7 +194,8 @@ def test_scheduler_scale_and_resilience(
                     # resolved, i.e. we can reliably ensure successful runs
                     if not any(
                         run.get("run_id") == run_id
-                        and run.get("state") in {"queued", "running", "failed", "success"}
+                        and run.get("state")
+                        in {"queued", "running", "failed", "success"}
                         for run in runs
                         if isinstance(runs, list)
                     ):


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
- Update `airflow_coordinator.py` charmlib to libpatch 6 (will be published when [coordinator PR 32](https://github.com/canonical/airflow-coordinator-k8s-operator/pull/32) is merged)
- Persist TLS CA chains for potential S3 connections if they are provided by airflow coordinator

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->
n/a

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->
The persistence of the TLS CA chains is crucial for accessing s3 connections that require TLS verification. This is provided by coordinator (in coordinator PR 32) when a relation with upstream s3-integrator is formed and dag bundles are added to `airflow.cfg` 

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
