### PR TITLE
feat: set trust var for scheduler

### DIFF
--- a/charms/scheduler/terraform/README.md
+++ b/charms/scheduler/terraform/README.md
@@ -21,6 +21,7 @@ The module offers the following configurable inputs:
 | `channel` | string | Channel that the charm is deployed from | False |
 | `constraints` | string | Constraints to deploy the charm with | False |
 | `config` | map(string) | Map of the charm configuration options | False |
+| `trust` | bool | Whether the charm is trusted | False |
 
 ### Outputs
 Upon applied, the module exports the following outputs:

--- a/charms/scheduler/terraform/main.tf
+++ b/charms/scheduler/terraform/main.tf
@@ -10,6 +10,7 @@ resource "juju_application" "airflow_scheduler_k8s" {
 
   constraints = var.constraints
   config      = var.config
+  trust       = var.trust
 
   units = var.units
 }

--- a/charms/scheduler/terraform/variables.tf
+++ b/charms/scheduler/terraform/variables.tf
@@ -33,6 +33,12 @@ variable "revision" {
   default     = null
 }
 
+variable "trust" {
+  type        = bool
+  description = "Whether to trust the application with cluster-wide access"
+  default     = false
+}
+
 variable "units" {
   type        = number
   description = "Number of units to deploy with this name and configuration"


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

`trust` should be an option for the scheduler when the Kubernetes Executor is to be used.

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

N/A

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
