### PR TITLE
[WF-429] Handle presence or absence of webserver config file in the airflow-coordinator relation data

### DIFF
--- a/charms/api-server/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/api-server/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -90,6 +90,12 @@ the pebble workload container
 to render and write the k8s executor pod spec
 8. `write_kubernetes_executor_pod_spec(filepath)`: renders and writes the k8s
 executor pod spec into the pebble workload container
+9. `can_write_webserver_config`: all prerequisities met to be able to render and
+write the webserver config file
+10. `webserver_config_needs_update(filepath)`: if the webserver config file in
+the relation has drifted from the contents of file on the workload container
+11. `write_webserver_config(filepath, user, group)`: write the webserver config
+file contents to the workload container
 
 `AirflowCoordinatorCoreRequires` will invoke the provided `callback` when:
 - the coordinator charm shares validation failures for all related core charms
@@ -165,7 +171,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)
@@ -269,15 +275,16 @@ class AirflowCoordinatorProviderModel(data_interfaces.BaseCommonModel):
     # (str from coordinator) and structured config dicts (from executor, deserialized
     # by data_interfaces' get_data). This will change when we refactor the library
     # to a much more generic one.
-    config_template: str | dict | None = None
-    kubernetes_executor_pod_spec: str | None = None
+    config_template: typing.Optional[str | dict] = None
+    kubernetes_executor_pod_spec: typing.Optional[str] = None
+    webserver_config_template: typing.Optional[str] = None
     sensitive_data: SensitiveDataSecretStr = None
-    secret_sensitive_data: data_interfaces.SecretString | None = None
+    secret_sensitive_data: typing.Optional[data_interfaces.SecretString] = None
 
-    validation_failures: str | None = None
+    validation_failures: typing.Optional[str] = None
 
     # CA chains for Airflow connections
-    tls_ca_chains: dict[str, str] | None = None
+    tls_ca_chains: typing.Optional[dict[str, str]] = None
 
     # hack to enable databag diff computation with data_interfaces v1 charm lib
     request_id: str = pydantic.Field(default="fixed_request_id", exclude=True)
@@ -315,8 +322,8 @@ class AirflowCoordinatorEvent(ops.EventBase, typing.Generic[TAirflowCoordinatorM
         self,
         handle: ops.Handle,
         relation: ops.Relation,
-        app: ops.Application | None,
-        unit: ops.Unit | None,
+        app: typing.Optional[ops.Application],
+        unit: typing.Optional[ops.Unit],
         content: TAirflowCoordinatorModels,
     ):
         super().__init__(handle)
@@ -659,6 +666,7 @@ class AirflowCoordinatorProviderEventHandler(
         self,
         config_template: str = None,
         kubernetes_executor_pod_spec: str = None,
+        webserver_config_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
         tls_ca_chains: dict[str, str] = {},
     ):
@@ -685,6 +693,7 @@ class AirflowCoordinatorProviderEventHandler(
                         model.config_template = config_template
 
                     model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
+                    model.webserver_config_template = webserver_config_template
 
                     if sensitive_data:
                         model.sensitive_data = json.dumps(sensitive_data)
@@ -699,6 +708,7 @@ class AirflowCoordinatorProviderEventHandler(
                 model = AirflowCoordinatorProviderModel(
                     config_template=config_template,
                     kubernetes_executor_pod_spec=kubernetes_executor_pod_spec,
+                    webserver_config_template=webserver_config_template,
                     sensitive_data=json.dumps(sensitive_data),
                     tls_ca_chains=tls_ca_chains,
                 )
@@ -726,6 +736,7 @@ class AirflowCoordinatorProviderEventHandler(
 
                     model.config_template = None
                     model.kubernetes_executor_pod_spec = None
+                    model.webserver_config_template = None
                     # a truthy value assigned to avoid underlying secret from being deleted
                     model.sensitive_data = json.dumps({})
 
@@ -1007,6 +1018,51 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         )
 
     @property
+    def can_write_webserver_config(self) -> bool:
+        """Indicate if it is safe to write webserver_config.py to the workload container.
+
+        Returns True when pebble is reachable, the relation is ready (no validation
+        errors), and the coordinator has shared a webserver config template and
+        sensitive data.
+        """
+        if not self._workload_container.can_connect():
+            return False
+        content = self._requirer_handler.provider_content
+        return bool(
+            self._ready
+            and content
+            and content.webserver_config_template
+            and content.sensitive_data
+        )
+
+    @property
+    def _webserver_config_from_relation(self) -> str:
+        """Render the webserver_config.py."""
+        provider_content = self._requirer_handler.provider_content
+
+        return jinja2.Template(provider_content.webserver_config_template).render(
+            **json.loads(provider_content.sensitive_data)
+        )
+
+    def webserver_config_needs_update(self, filepath: str) -> bool:
+        """Check if webserver config file needs to be updated on workload container.
+
+        Return True if the rendered webserver config differs from the file on disk; False otherwise
+        """
+        if self._workload_container.exists(filepath):
+            on_disk = self._workload_container.pull(filepath).read()
+        else:
+            on_disk = None
+
+        return on_disk != self._webserver_config_from_relation
+
+    def write_webserver_config(self, filepath: str, user: str, group: str) -> None:
+        """Render and write webserver_config.py in the workload container."""
+        self._workload_container.push(
+            filepath, self._webserver_config_from_relation, user=user, group=group, make_dirs=True
+        )
+
+    @property
     def can_write_tls_ca_chain(self) -> bool:
         """Indicate if there exist tls ca chains to write to workload container.
 
@@ -1185,6 +1241,7 @@ class AirflowCoordinatorProvides(ops.Object):
         self,
         config_template: typing.Optional[str] = None,
         k8s_executor_pod_spec_template: typing.Optional[str] = None,
+        webserver_config_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
         tls_ca_chains: dict[str, str] = {},
     ) -> None:
@@ -1193,6 +1250,7 @@ class AirflowCoordinatorProvides(ops.Object):
         Args:
             config_template: Airflow config as a Jinja2 template string.
             k8s_executor_pod_spec_template: (optional) K8s executor pod spec template.
+            webserver_config_template: (optional) Webserver config template for FAB OAuth.
             sensitive_data: sensitive data to render config of k8s executor pod
                 spec jinja templates with.
             tls_ca_chains: mapping from filename to tls ca chain file contents
@@ -1200,6 +1258,7 @@ class AirflowCoordinatorProvides(ops.Object):
         self._provider_handler.update_content(
             config_template=config_template,
             kubernetes_executor_pod_spec=k8s_executor_pod_spec_template,
+            webserver_config_template=webserver_config_template,
             sensitive_data=sensitive_data,
             tls_ca_chains=tls_ca_chains,
         )

--- a/charms/api-server/pyproject.toml
+++ b/charms/api-server/pyproject.toml
@@ -69,7 +69,7 @@ lint.ignore = [
     "D413",
 ]
 extend-exclude = ["__pycache__", "*.egg_info"]
-lint.per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+lint.per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104", "D205"]}
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/charms/api-server/src/charm.py
+++ b/charms/api-server/src/charm.py
@@ -206,6 +206,74 @@ class AirflowApiServerCharm(ops.CharmBase):
                 ops.BlockedStatus,
             )
 
+    def _handle_webserver_config(self) -> bool:
+        """Write or remove webserver_config.py based on coordinator relation data.
+
+        Delegates to AirflowCoordinatorCoreRequires when the coordinator has shared
+        a webserver config template; falls back to removing any stale file when OAuth
+        is no longer active.
+
+        Returns:
+            True if the file was created, updated, or removed (service restart
+            warranted), False otherwise.
+
+        Raises:
+            ExitWithStatusError: If a Pebble operation fails.
+        """
+        if self._config_requires.can_write_webserver_config:
+            try:
+                needs_update = self._config_requires.webserver_config_needs_update(
+                    constants.WEBSERVER_CONFIG_PATH
+                )
+            except (ops.pebble.ConnectionError, ops.pebble.PathError) as e:
+                logger.exception("Failed to check webserver_config.py: %s", e)
+                raise ExitWithStatusError(
+                    constants.FAILED_TO_CHECK_WEBSERVER_CONFIG_UPDATE_MESSAGE,
+                    ops.BlockedStatus,
+                )
+
+            if not needs_update:
+                return False
+
+            try:
+                self._config_requires.write_webserver_config(
+                    filepath=constants.WEBSERVER_CONFIG_PATH,
+                    user=constants.WORKLOAD_USER,
+                    group=constants.WORKLOAD_GROUP,
+                )
+            except (ops.pebble.ConnectionError, ops.pebble.Error) as e:
+                logger.exception("Failed to write webserver_config.py: %s", e)
+                raise ExitWithStatusError(
+                    constants.FAILED_TO_WRITE_WEBSERVER_CONFIG_MESSAGE,
+                    ops.BlockedStatus,
+                )
+
+            return True
+
+        # OAuth not active — remove any stale file from a previous OAuth relation.
+        try:
+            file_exists = self._container.exists(constants.WEBSERVER_CONFIG_PATH)
+        except ops.pebble.ConnectionError as e:
+            logger.exception("Pebble connection error checking webserver_config.py: %s", e)
+            raise ExitWithStatusError(
+                constants.FAILED_TO_CHECK_WEBSERVER_CONFIG_EXISTS_MESSAGE,
+                ops.BlockedStatus,
+            )
+
+        if not file_exists:
+            return False
+
+        try:
+            self._container.remove_path(constants.WEBSERVER_CONFIG_PATH)
+        except (ops.pebble.ConnectionError, ops.pebble.PathError) as e:
+            logger.exception("Failed to remove webserver_config.py: %s", e)
+            raise ExitWithStatusError(
+                constants.FAILED_TO_REMOVE_WEBSERVER_CONFIG_MESSAGE,
+                ops.BlockedStatus,
+            )
+
+        return True
+
     def _reconcile(self, _) -> None:
         """Reconcile the charm state."""
         try:
@@ -225,12 +293,16 @@ class AirflowApiServerCharm(ops.CharmBase):
             if airflow_config_updated:
                 self._write_airflow_config(config_path=constants.AIRFLOW_CONFIG_PATH)
 
+            webserver_config_updated = self._handle_webserver_config()
+
             if self._config_requires.can_write_tls_ca_chain:
                 self._config_requires.write_tls_ca_chains(
                     constants.WORKLOAD_USER, constants.WORKLOAD_GROUP
                 )
 
-            self._add_layer_and_replan(restart_service=airflow_config_updated)
+            self._add_layer_and_replan(
+                restart_service=airflow_config_updated or webserver_config_updated
+            )
         except ExitWithStatusError as e:
             self.unit.status = e.status
             return

--- a/charms/api-server/src/constants.py
+++ b/charms/api-server/src/constants.py
@@ -9,5 +9,19 @@ AIRFLOW_API_SERVER_RELATION_ENDPOINT = "airflow-api-server"
 TRAEFIK_INGRESS_RELATION_ENDPOINT = "ingress"
 AIRFLOW_HOME = "/opt/airflow"
 AIRFLOW_CONFIG_PATH = f"{AIRFLOW_HOME}/airflow.cfg"
+WEBSERVER_CONFIG_PATH = f"{AIRFLOW_HOME}/webserver_config.py"
 WORKLOAD_USER = "ubuntu"
 WORKLOAD_GROUP = "ubuntu"
+
+FAILED_TO_CHECK_WEBSERVER_CONFIG_UPDATE_MESSAGE = (
+    "Failed to check webserver_config.py needs update."
+)
+FAILED_TO_WRITE_WEBSERVER_CONFIG_MESSAGE = (
+    "Failed to write webserver_config.py to workload container"
+)
+FAILED_TO_CHECK_WEBSERVER_CONFIG_EXISTS_MESSAGE = (
+    "Failed to check if webserver_config.py exists in workload container"
+)
+FAILED_TO_REMOVE_WEBSERVER_CONFIG_MESSAGE = (
+    "Failed to remove webserver_config.py in workload container"
+)

--- a/charms/api-server/tests/scenario/test_oauth.py
+++ b/charms/api-server/tests/scenario/test_oauth.py
@@ -1,0 +1,287 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for webserver_config.py handling for OAuth in the API Server charm."""
+
+import dataclasses
+import unittest.mock
+
+import ops
+import ops.testing
+from charms.airflow_coordinator_k8s.v0.airflow_coordinator import AirflowCoordinatorCoreRequires
+
+import constants
+
+
+def _patch_coordinator_ready():
+    """Patch AirflowCoordinatorCoreRequires so the coordinator appears fully
+    ready and the webserver config is NOT active (default baseline).
+    """
+    return unittest.mock.patch.multiple(
+        AirflowCoordinatorCoreRequires,
+        can_write_airflow_config=unittest.mock.PropertyMock(return_value=True),
+        airflow_config_needs_update=unittest.mock.MagicMock(return_value=False),
+        write_airflow_config=unittest.mock.MagicMock(return_value=None),
+        can_write_webserver_config=unittest.mock.PropertyMock(return_value=False),
+    )
+
+
+def _patch_coordinator_ready_with_webserver(needs_update: bool = True):
+    """Patch so the coordinator is fully ready AND webserver config is active."""
+    return unittest.mock.patch.multiple(
+        AirflowCoordinatorCoreRequires,
+        can_write_airflow_config=unittest.mock.PropertyMock(return_value=True),
+        airflow_config_needs_update=unittest.mock.MagicMock(return_value=False),
+        write_airflow_config=unittest.mock.MagicMock(return_value=None),
+        can_write_webserver_config=unittest.mock.PropertyMock(return_value=True),
+        webserver_config_needs_update=unittest.mock.MagicMock(return_value=needs_update),
+        write_webserver_config=unittest.mock.MagicMock(return_value=None),
+    )
+
+
+class TestWebserverConfigHandling:
+    def test_webserver_config_written_when_active_and_needs_update(
+        self, context, state, container, api_server_relation
+    ):
+        """When can_write_webserver_config is True and needs_update is True,
+        write_webserver_config is called and the charm reaches ActiveStatus.
+        """
+        state_in = dataclasses.replace(
+            state,
+            relations=[api_server_relation],
+        )
+
+        with (
+            _patch_coordinator_ready_with_webserver(needs_update=True),
+            unittest.mock.patch.object(
+                AirflowCoordinatorCoreRequires,
+                "write_webserver_config",
+            ) as write_mock,
+        ):
+            state_out = context.run(context.on.pebble_ready(container), state_in)
+
+        assert state_out.unit_status == ops.ActiveStatus()
+
+        write_mock.assert_called_once_with(
+            filepath=constants.WEBSERVER_CONFIG_PATH,
+            user=constants.WORKLOAD_USER,
+            group=constants.WORKLOAD_GROUP,
+        )
+
+    def test_webserver_config_not_written_when_content_unchanged(
+        self, context, state, container, api_server_relation
+    ):
+        """When can_write_webserver_config is True but needs_update is False,
+        write_webserver_config is not called and the service is not restarted.
+        """
+        state_in = dataclasses.replace(
+            state,
+            relations=[api_server_relation],
+        )
+
+        with (
+            _patch_coordinator_ready_with_webserver(needs_update=False),
+            unittest.mock.patch.object(
+                AirflowCoordinatorCoreRequires,
+                "write_webserver_config",
+            ) as write_mock,
+            unittest.mock.patch("ops.model.Container.restart", autospec=True) as restart_mock,
+        ):
+            state_out = context.run(context.on.pebble_ready(container), state_in)
+
+        assert state_out.unit_status == ops.ActiveStatus()
+
+        write_mock.assert_not_called()
+        restart_mock.assert_not_called()
+
+    def test_service_restarted_when_webserver_config_written(
+        self, context, state, container, api_server_relation
+    ):
+        """When write_webserver_config is called the service is restarted."""
+        state_in = dataclasses.replace(
+            state,
+            relations=[api_server_relation],
+        )
+
+        with (
+            _patch_coordinator_ready_with_webserver(needs_update=True),
+            unittest.mock.patch("ops.model.Container.restart", autospec=True) as restart_mock,
+        ):
+            state_out = context.run(context.on.pebble_ready(container), state_in)
+
+        assert state_out.unit_status == ops.ActiveStatus()
+
+        restart_mock.assert_called_once()
+
+    def test_stale_webserver_config_removed_when_oauth_inactive(
+        self, context, state, container, api_server_relation
+    ):
+        """When can_write_webserver_config is False but the file exists on
+        disk, the file is removed and the service restarts.
+        """
+        state_in = dataclasses.replace(
+            state,
+            relations=[api_server_relation],
+        )
+
+        with (
+            _patch_coordinator_ready(),
+            unittest.mock.patch("ops.model.Container.exists", autospec=True, return_value=True),
+            unittest.mock.patch("ops.model.Container.remove_path", autospec=True) as remove_mock,
+            unittest.mock.patch("ops.model.Container.restart", autospec=True) as restart_mock,
+        ):
+            state_out = context.run(context.on.pebble_ready(container), state_in)
+
+        assert state_out.unit_status == ops.ActiveStatus()
+
+        remove_mock.assert_called_once()
+        restart_mock.assert_called_once()
+
+    def test_no_action_when_oauth_inactive_and_no_file_on_disk(
+        self, context, state, container, api_server_relation
+    ):
+        """When can_write_webserver_config is False and no file exists on
+        disk, no remove and no restart.
+        """
+        state_in = dataclasses.replace(
+            state,
+            relations=[api_server_relation],
+        )
+
+        with (
+            _patch_coordinator_ready(),
+            unittest.mock.patch("ops.model.Container.exists", autospec=True, return_value=False),
+            unittest.mock.patch("ops.model.Container.remove_path", autospec=True) as remove_mock,
+            unittest.mock.patch("ops.model.Container.restart", autospec=True) as restart_mock,
+        ):
+            state_out = context.run(context.on.pebble_ready(container), state_in)
+
+        assert state_out.unit_status == ops.ActiveStatus()
+
+        remove_mock.assert_not_called()
+        restart_mock.assert_not_called()
+
+    def test_error_on_needs_update_check_goes_blocked(
+        self, context, state, container, api_server_relation
+    ):
+        """A ConnectionError during webserver_config_needs_update results in
+        BlockedStatus.
+        """
+        state_in = dataclasses.replace(
+            state,
+            relations=[api_server_relation],
+        )
+
+        with (
+            unittest.mock.patch.multiple(
+                AirflowCoordinatorCoreRequires,
+                can_write_airflow_config=unittest.mock.PropertyMock(return_value=True),
+                airflow_config_needs_update=unittest.mock.MagicMock(return_value=False),
+                write_airflow_config=unittest.mock.MagicMock(return_value=None),
+                can_write_webserver_config=unittest.mock.PropertyMock(return_value=True),
+                webserver_config_needs_update=unittest.mock.MagicMock(
+                    side_effect=ops.pebble.ConnectionError("cannot connect")
+                ),
+            ),
+        ):
+            state_out = context.run(context.on.pebble_ready(container), state_in)
+
+        assert state_out.unit_status == ops.BlockedStatus(
+            constants.FAILED_TO_CHECK_WEBSERVER_CONFIG_UPDATE_MESSAGE
+        )
+
+    def test_error_on_write_webserver_config_goes_blocked(
+        self, context, state, container, api_server_relation
+    ):
+        """A ConnectionError during webserver_config_needs_update results in
+        BlockedStatus.
+        """
+        state_in = dataclasses.replace(
+            state,
+            relations=[api_server_relation],
+        )
+
+        with (
+            unittest.mock.patch.multiple(
+                AirflowCoordinatorCoreRequires,
+                can_write_airflow_config=unittest.mock.PropertyMock(return_value=True),
+                airflow_config_needs_update=unittest.mock.MagicMock(return_value=False),
+                write_airflow_config=unittest.mock.MagicMock(return_vlaue=True),
+                can_write_webserver_config=unittest.mock.PropertyMock(return_value=True),
+                webserver_config_needs_update=unittest.mock.MagicMock(return_value=True),
+                write_webserver_config=unittest.mock.MagicMock(
+                    side_effect=ops.pebble.ConnectionError("cannot connect")
+                ),
+            ),
+        ):
+            state_out = context.run(context.on.pebble_ready(container), state_in)
+
+        assert state_out.unit_status == ops.BlockedStatus(
+            constants.FAILED_TO_WRITE_WEBSERVER_CONFIG_MESSAGE
+        )
+
+    def test_error_on_check_webserver_config_exists_goes_blocked(
+        self, context, state, container, api_server_relation
+    ):
+        """A ConnectionError during webserver_config_needs_update results in
+        BlockedStatus.
+        """
+        state_in = dataclasses.replace(
+            state,
+            relations=[api_server_relation],
+        )
+
+        with (
+            unittest.mock.patch.multiple(
+                AirflowCoordinatorCoreRequires,
+                can_write_airflow_config=unittest.mock.PropertyMock(return_value=True),
+                airflow_config_needs_update=unittest.mock.MagicMock(return_value=False),
+                write_airflow_config=unittest.mock.MagicMock(return_vlaue=True),
+                can_write_webserver_config=unittest.mock.PropertyMock(return_value=False),
+            ),
+            unittest.mock.patch.object(
+                ops.Container,
+                "exists",
+                side_effect=unittest.mock.MagicMock(
+                    side_effect=ops.pebble.ConnectionError("cannot connect")
+                ),
+            ),
+        ):
+            state_out = context.run(context.on.pebble_ready(container), state_in)
+
+        assert state_out.unit_status == ops.BlockedStatus(
+            constants.FAILED_TO_CHECK_WEBSERVER_CONFIG_EXISTS_MESSAGE
+        )
+
+    def test_error_on_remove_webserver_config_goes_blocked(
+        self, context, state, container, api_server_relation
+    ):
+        """A ConnectionError during webserver_config_needs_update results in
+        BlockedStatus.
+        """
+        state_in = dataclasses.replace(
+            state,
+            relations=[api_server_relation],
+        )
+
+        with (
+            unittest.mock.patch.multiple(
+                AirflowCoordinatorCoreRequires,
+                can_write_airflow_config=unittest.mock.PropertyMock(return_value=True),
+                airflow_config_needs_update=unittest.mock.MagicMock(return_value=False),
+                write_airflow_config=unittest.mock.MagicMock(return_vlaue=True),
+                can_write_webserver_config=unittest.mock.PropertyMock(return_value=False),
+            ),
+            unittest.mock.patch.multiple(
+                ops.Container,
+                exists=unittest.mock.MagicMock(return_value=True),
+                remove_path=unittest.mock.MagicMock(
+                    side_effect=ops.pebble.ConnectionError("cannot connect")
+                ),
+            ),
+        ):
+            state_out = context.run(context.on.pebble_ready(container), state_in)
+
+        assert state_out.unit_status == ops.BlockedStatus(
+            constants.FAILED_TO_REMOVE_WEBSERVER_CONFIG_MESSAGE
+        )

--- a/charms/api-server/tests/scenario/test_oauth.py
+++ b/charms/api-server/tests/scenario/test_oauth.py
@@ -206,7 +206,7 @@ class TestWebserverConfigHandling:
                 AirflowCoordinatorCoreRequires,
                 can_write_airflow_config=unittest.mock.PropertyMock(return_value=True),
                 airflow_config_needs_update=unittest.mock.MagicMock(return_value=False),
-                write_airflow_config=unittest.mock.MagicMock(return_vlaue=True),
+                write_airflow_config=unittest.mock.MagicMock(return_value=True),
                 can_write_webserver_config=unittest.mock.PropertyMock(return_value=True),
                 webserver_config_needs_update=unittest.mock.MagicMock(return_value=True),
                 write_webserver_config=unittest.mock.MagicMock(
@@ -236,7 +236,7 @@ class TestWebserverConfigHandling:
                 AirflowCoordinatorCoreRequires,
                 can_write_airflow_config=unittest.mock.PropertyMock(return_value=True),
                 airflow_config_needs_update=unittest.mock.MagicMock(return_value=False),
-                write_airflow_config=unittest.mock.MagicMock(return_vlaue=True),
+                write_airflow_config=unittest.mock.MagicMock(return_value=True),
                 can_write_webserver_config=unittest.mock.PropertyMock(return_value=False),
             ),
             unittest.mock.patch.object(
@@ -269,7 +269,7 @@ class TestWebserverConfigHandling:
                 AirflowCoordinatorCoreRequires,
                 can_write_airflow_config=unittest.mock.PropertyMock(return_value=True),
                 airflow_config_needs_update=unittest.mock.MagicMock(return_value=False),
-                write_airflow_config=unittest.mock.MagicMock(return_vlaue=True),
+                write_airflow_config=unittest.mock.MagicMock(return_value=True),
                 can_write_webserver_config=unittest.mock.PropertyMock(return_value=False),
             ),
             unittest.mock.patch.multiple(

--- a/charms/api-server/tox.ini
+++ b/charms/api-server/tox.ini
@@ -57,7 +57,7 @@ allowlist_externals =
 commands =
     uv sync --active --group unit
     uv run coverage run \
-        --source={[vars]src_path} --source={[vars]lib_path} --module pytest \
+        --source={[vars]src_path},{[vars]lib_path} --module pytest \
         {[vars]tests_path}/scenario \
         {posargs}
     uv tool run {[vars]uv_flags} coverage report

--- a/charms/dag-processor/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/dag-processor/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -90,6 +90,12 @@ the pebble workload container
 to render and write the k8s executor pod spec
 8. `write_kubernetes_executor_pod_spec(filepath)`: renders and writes the k8s
 executor pod spec into the pebble workload container
+9. `can_write_webserver_config`: all prerequisities met to be able to render and
+write the webserver config file
+10. `webserver_config_needs_update(filepath)`: if the webserver config file in
+the relation has drifted from the contents of file on the workload container
+11. `write_webserver_config(filepath, user, group)`: write the webserver config
+file contents to the workload container
 
 `AirflowCoordinatorCoreRequires` will invoke the provided `callback` when:
 - the coordinator charm shares validation failures for all related core charms
@@ -165,7 +171,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)
@@ -269,15 +275,16 @@ class AirflowCoordinatorProviderModel(data_interfaces.BaseCommonModel):
     # (str from coordinator) and structured config dicts (from executor, deserialized
     # by data_interfaces' get_data). This will change when we refactor the library
     # to a much more generic one.
-    config_template: str | dict | None = None
-    kubernetes_executor_pod_spec: str | None = None
+    config_template: typing.Optional[str | dict] = None
+    kubernetes_executor_pod_spec: typing.Optional[str] = None
+    webserver_config_template: typing.Optional[str] = None
     sensitive_data: SensitiveDataSecretStr = None
-    secret_sensitive_data: data_interfaces.SecretString | None = None
+    secret_sensitive_data: typing.Optional[data_interfaces.SecretString] = None
 
-    validation_failures: str | None = None
+    validation_failures: typing.Optional[str] = None
 
     # CA chains for Airflow connections
-    tls_ca_chains: dict[str, str] | None = None
+    tls_ca_chains: typing.Optional[dict[str, str]] = None
 
     # hack to enable databag diff computation with data_interfaces v1 charm lib
     request_id: str = pydantic.Field(default="fixed_request_id", exclude=True)
@@ -315,8 +322,8 @@ class AirflowCoordinatorEvent(ops.EventBase, typing.Generic[TAirflowCoordinatorM
         self,
         handle: ops.Handle,
         relation: ops.Relation,
-        app: ops.Application | None,
-        unit: ops.Unit | None,
+        app: typing.Optional[ops.Application],
+        unit: typing.Optional[ops.Unit],
         content: TAirflowCoordinatorModels,
     ):
         super().__init__(handle)
@@ -659,6 +666,7 @@ class AirflowCoordinatorProviderEventHandler(
         self,
         config_template: str = None,
         kubernetes_executor_pod_spec: str = None,
+        webserver_config_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
         tls_ca_chains: dict[str, str] = {},
     ):
@@ -685,6 +693,7 @@ class AirflowCoordinatorProviderEventHandler(
                         model.config_template = config_template
 
                     model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
+                    model.webserver_config_template = webserver_config_template
 
                     if sensitive_data:
                         model.sensitive_data = json.dumps(sensitive_data)
@@ -699,6 +708,7 @@ class AirflowCoordinatorProviderEventHandler(
                 model = AirflowCoordinatorProviderModel(
                     config_template=config_template,
                     kubernetes_executor_pod_spec=kubernetes_executor_pod_spec,
+                    webserver_config_template=webserver_config_template,
                     sensitive_data=json.dumps(sensitive_data),
                     tls_ca_chains=tls_ca_chains,
                 )
@@ -726,6 +736,7 @@ class AirflowCoordinatorProviderEventHandler(
 
                     model.config_template = None
                     model.kubernetes_executor_pod_spec = None
+                    model.webserver_config_template = None
                     # a truthy value assigned to avoid underlying secret from being deleted
                     model.sensitive_data = json.dumps({})
 
@@ -1007,6 +1018,51 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         )
 
     @property
+    def can_write_webserver_config(self) -> bool:
+        """Indicate if it is safe to write webserver_config.py to the workload container.
+
+        Returns True when pebble is reachable, the relation is ready (no validation
+        errors), and the coordinator has shared a webserver config template and
+        sensitive data.
+        """
+        if not self._workload_container.can_connect():
+            return False
+        content = self._requirer_handler.provider_content
+        return bool(
+            self._ready
+            and content
+            and content.webserver_config_template
+            and content.sensitive_data
+        )
+
+    @property
+    def _webserver_config_from_relation(self) -> str:
+        """Render the webserver_config.py."""
+        provider_content = self._requirer_handler.provider_content
+
+        return jinja2.Template(provider_content.webserver_config_template).render(
+            **json.loads(provider_content.sensitive_data)
+        )
+
+    def webserver_config_needs_update(self, filepath: str) -> bool:
+        """Check if webserver config file needs to be updated on workload container.
+
+        Return True if the rendered webserver config differs from the file on disk; False otherwise
+        """
+        if self._workload_container.exists(filepath):
+            on_disk = self._workload_container.pull(filepath).read()
+        else:
+            on_disk = None
+
+        return on_disk != self._webserver_config_from_relation
+
+    def write_webserver_config(self, filepath: str, user: str, group: str) -> None:
+        """Render and write webserver_config.py in the workload container."""
+        self._workload_container.push(
+            filepath, self._webserver_config_from_relation, user=user, group=group, make_dirs=True
+        )
+
+    @property
     def can_write_tls_ca_chain(self) -> bool:
         """Indicate if there exist tls ca chains to write to workload container.
 
@@ -1185,6 +1241,7 @@ class AirflowCoordinatorProvides(ops.Object):
         self,
         config_template: typing.Optional[str] = None,
         k8s_executor_pod_spec_template: typing.Optional[str] = None,
+        webserver_config_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
         tls_ca_chains: dict[str, str] = {},
     ) -> None:
@@ -1193,6 +1250,7 @@ class AirflowCoordinatorProvides(ops.Object):
         Args:
             config_template: Airflow config as a Jinja2 template string.
             k8s_executor_pod_spec_template: (optional) K8s executor pod spec template.
+            webserver_config_template: (optional) Webserver config template for FAB OAuth.
             sensitive_data: sensitive data to render config of k8s executor pod
                 spec jinja templates with.
             tls_ca_chains: mapping from filename to tls ca chain file contents
@@ -1200,6 +1258,7 @@ class AirflowCoordinatorProvides(ops.Object):
         self._provider_handler.update_content(
             config_template=config_template,
             kubernetes_executor_pod_spec=k8s_executor_pod_spec_template,
+            webserver_config_template=webserver_config_template,
             sensitive_data=sensitive_data,
             tls_ca_chains=tls_ca_chains,
         )

--- a/charms/scheduler/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/scheduler/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -90,6 +90,12 @@ the pebble workload container
 to render and write the k8s executor pod spec
 8. `write_kubernetes_executor_pod_spec(filepath)`: renders and writes the k8s
 executor pod spec into the pebble workload container
+9. `can_write_webserver_config`: all prerequisities met to be able to render and
+write the webserver config file
+10. `webserver_config_needs_update(filepath)`: if the webserver config file in
+the relation has drifted from the contents of file on the workload container
+11. `write_webserver_config(filepath, user, group)`: write the webserver config
+file contents to the workload container
 
 `AirflowCoordinatorCoreRequires` will invoke the provided `callback` when:
 - the coordinator charm shares validation failures for all related core charms
@@ -165,7 +171,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)
@@ -269,15 +275,16 @@ class AirflowCoordinatorProviderModel(data_interfaces.BaseCommonModel):
     # (str from coordinator) and structured config dicts (from executor, deserialized
     # by data_interfaces' get_data). This will change when we refactor the library
     # to a much more generic one.
-    config_template: str | dict | None = None
-    kubernetes_executor_pod_spec: str | None = None
+    config_template: typing.Optional[str | dict] = None
+    kubernetes_executor_pod_spec: typing.Optional[str] = None
+    webserver_config_template: typing.Optional[str] = None
     sensitive_data: SensitiveDataSecretStr = None
-    secret_sensitive_data: data_interfaces.SecretString | None = None
+    secret_sensitive_data: typing.Optional[data_interfaces.SecretString] = None
 
-    validation_failures: str | None = None
+    validation_failures: typing.Optional[str] = None
 
     # CA chains for Airflow connections
-    tls_ca_chains: dict[str, str] | None = None
+    tls_ca_chains: typing.Optional[dict[str, str]] = None
 
     # hack to enable databag diff computation with data_interfaces v1 charm lib
     request_id: str = pydantic.Field(default="fixed_request_id", exclude=True)
@@ -315,8 +322,8 @@ class AirflowCoordinatorEvent(ops.EventBase, typing.Generic[TAirflowCoordinatorM
         self,
         handle: ops.Handle,
         relation: ops.Relation,
-        app: ops.Application | None,
-        unit: ops.Unit | None,
+        app: typing.Optional[ops.Application],
+        unit: typing.Optional[ops.Unit],
         content: TAirflowCoordinatorModels,
     ):
         super().__init__(handle)
@@ -659,6 +666,7 @@ class AirflowCoordinatorProviderEventHandler(
         self,
         config_template: str = None,
         kubernetes_executor_pod_spec: str = None,
+        webserver_config_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
         tls_ca_chains: dict[str, str] = {},
     ):
@@ -685,6 +693,7 @@ class AirflowCoordinatorProviderEventHandler(
                         model.config_template = config_template
 
                     model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
+                    model.webserver_config_template = webserver_config_template
 
                     if sensitive_data:
                         model.sensitive_data = json.dumps(sensitive_data)
@@ -699,6 +708,7 @@ class AirflowCoordinatorProviderEventHandler(
                 model = AirflowCoordinatorProviderModel(
                     config_template=config_template,
                     kubernetes_executor_pod_spec=kubernetes_executor_pod_spec,
+                    webserver_config_template=webserver_config_template,
                     sensitive_data=json.dumps(sensitive_data),
                     tls_ca_chains=tls_ca_chains,
                 )
@@ -726,6 +736,7 @@ class AirflowCoordinatorProviderEventHandler(
 
                     model.config_template = None
                     model.kubernetes_executor_pod_spec = None
+                    model.webserver_config_template = None
                     # a truthy value assigned to avoid underlying secret from being deleted
                     model.sensitive_data = json.dumps({})
 
@@ -1007,6 +1018,51 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         )
 
     @property
+    def can_write_webserver_config(self) -> bool:
+        """Indicate if it is safe to write webserver_config.py to the workload container.
+
+        Returns True when pebble is reachable, the relation is ready (no validation
+        errors), and the coordinator has shared a webserver config template and
+        sensitive data.
+        """
+        if not self._workload_container.can_connect():
+            return False
+        content = self._requirer_handler.provider_content
+        return bool(
+            self._ready
+            and content
+            and content.webserver_config_template
+            and content.sensitive_data
+        )
+
+    @property
+    def _webserver_config_from_relation(self) -> str:
+        """Render the webserver_config.py."""
+        provider_content = self._requirer_handler.provider_content
+
+        return jinja2.Template(provider_content.webserver_config_template).render(
+            **json.loads(provider_content.sensitive_data)
+        )
+
+    def webserver_config_needs_update(self, filepath: str) -> bool:
+        """Check if webserver config file needs to be updated on workload container.
+
+        Return True if the rendered webserver config differs from the file on disk; False otherwise
+        """
+        if self._workload_container.exists(filepath):
+            on_disk = self._workload_container.pull(filepath).read()
+        else:
+            on_disk = None
+
+        return on_disk != self._webserver_config_from_relation
+
+    def write_webserver_config(self, filepath: str, user: str, group: str) -> None:
+        """Render and write webserver_config.py in the workload container."""
+        self._workload_container.push(
+            filepath, self._webserver_config_from_relation, user=user, group=group, make_dirs=True
+        )
+
+    @property
     def can_write_tls_ca_chain(self) -> bool:
         """Indicate if there exist tls ca chains to write to workload container.
 
@@ -1185,6 +1241,7 @@ class AirflowCoordinatorProvides(ops.Object):
         self,
         config_template: typing.Optional[str] = None,
         k8s_executor_pod_spec_template: typing.Optional[str] = None,
+        webserver_config_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
         tls_ca_chains: dict[str, str] = {},
     ) -> None:
@@ -1193,6 +1250,7 @@ class AirflowCoordinatorProvides(ops.Object):
         Args:
             config_template: Airflow config as a Jinja2 template string.
             k8s_executor_pod_spec_template: (optional) K8s executor pod spec template.
+            webserver_config_template: (optional) Webserver config template for FAB OAuth.
             sensitive_data: sensitive data to render config of k8s executor pod
                 spec jinja templates with.
             tls_ca_chains: mapping from filename to tls ca chain file contents
@@ -1200,6 +1258,7 @@ class AirflowCoordinatorProvides(ops.Object):
         self._provider_handler.update_content(
             config_template=config_template,
             kubernetes_executor_pod_spec=k8s_executor_pod_spec_template,
+            webserver_config_template=webserver_config_template,
             sensitive_data=sensitive_data,
             tls_ca_chains=tls_ca_chains,
         )

--- a/charms/triggerer/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/charms/triggerer/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -90,6 +90,12 @@ the pebble workload container
 to render and write the k8s executor pod spec
 8. `write_kubernetes_executor_pod_spec(filepath)`: renders and writes the k8s
 executor pod spec into the pebble workload container
+9. `can_write_webserver_config`: all prerequisities met to be able to render and
+write the webserver config file
+10. `webserver_config_needs_update(filepath)`: if the webserver config file in
+the relation has drifted from the contents of file on the workload container
+11. `write_webserver_config(filepath, user, group)`: write the webserver config
+file contents to the workload container
 
 `AirflowCoordinatorCoreRequires` will invoke the provided `callback` when:
 - the coordinator charm shares validation failures for all related core charms
@@ -165,7 +171,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)
@@ -269,15 +275,16 @@ class AirflowCoordinatorProviderModel(data_interfaces.BaseCommonModel):
     # (str from coordinator) and structured config dicts (from executor, deserialized
     # by data_interfaces' get_data). This will change when we refactor the library
     # to a much more generic one.
-    config_template: str | dict | None = None
-    kubernetes_executor_pod_spec: str | None = None
+    config_template: typing.Optional[str | dict] = None
+    kubernetes_executor_pod_spec: typing.Optional[str] = None
+    webserver_config_template: typing.Optional[str] = None
     sensitive_data: SensitiveDataSecretStr = None
-    secret_sensitive_data: data_interfaces.SecretString | None = None
+    secret_sensitive_data: typing.Optional[data_interfaces.SecretString] = None
 
-    validation_failures: str | None = None
+    validation_failures: typing.Optional[str] = None
 
     # CA chains for Airflow connections
-    tls_ca_chains: dict[str, str] | None = None
+    tls_ca_chains: typing.Optional[dict[str, str]] = None
 
     # hack to enable databag diff computation with data_interfaces v1 charm lib
     request_id: str = pydantic.Field(default="fixed_request_id", exclude=True)
@@ -315,8 +322,8 @@ class AirflowCoordinatorEvent(ops.EventBase, typing.Generic[TAirflowCoordinatorM
         self,
         handle: ops.Handle,
         relation: ops.Relation,
-        app: ops.Application | None,
-        unit: ops.Unit | None,
+        app: typing.Optional[ops.Application],
+        unit: typing.Optional[ops.Unit],
         content: TAirflowCoordinatorModels,
     ):
         super().__init__(handle)
@@ -659,6 +666,7 @@ class AirflowCoordinatorProviderEventHandler(
         self,
         config_template: str = None,
         kubernetes_executor_pod_spec: str = None,
+        webserver_config_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
         tls_ca_chains: dict[str, str] = {},
     ):
@@ -685,6 +693,7 @@ class AirflowCoordinatorProviderEventHandler(
                         model.config_template = config_template
 
                     model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
+                    model.webserver_config_template = webserver_config_template
 
                     if sensitive_data:
                         model.sensitive_data = json.dumps(sensitive_data)
@@ -699,6 +708,7 @@ class AirflowCoordinatorProviderEventHandler(
                 model = AirflowCoordinatorProviderModel(
                     config_template=config_template,
                     kubernetes_executor_pod_spec=kubernetes_executor_pod_spec,
+                    webserver_config_template=webserver_config_template,
                     sensitive_data=json.dumps(sensitive_data),
                     tls_ca_chains=tls_ca_chains,
                 )
@@ -726,6 +736,7 @@ class AirflowCoordinatorProviderEventHandler(
 
                     model.config_template = None
                     model.kubernetes_executor_pod_spec = None
+                    model.webserver_config_template = None
                     # a truthy value assigned to avoid underlying secret from being deleted
                     model.sensitive_data = json.dumps({})
 
@@ -1007,6 +1018,51 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         )
 
     @property
+    def can_write_webserver_config(self) -> bool:
+        """Indicate if it is safe to write webserver_config.py to the workload container.
+
+        Returns True when pebble is reachable, the relation is ready (no validation
+        errors), and the coordinator has shared a webserver config template and
+        sensitive data.
+        """
+        if not self._workload_container.can_connect():
+            return False
+        content = self._requirer_handler.provider_content
+        return bool(
+            self._ready
+            and content
+            and content.webserver_config_template
+            and content.sensitive_data
+        )
+
+    @property
+    def _webserver_config_from_relation(self) -> str:
+        """Render the webserver_config.py."""
+        provider_content = self._requirer_handler.provider_content
+
+        return jinja2.Template(provider_content.webserver_config_template).render(
+            **json.loads(provider_content.sensitive_data)
+        )
+
+    def webserver_config_needs_update(self, filepath: str) -> bool:
+        """Check if webserver config file needs to be updated on workload container.
+
+        Return True if the rendered webserver config differs from the file on disk; False otherwise
+        """
+        if self._workload_container.exists(filepath):
+            on_disk = self._workload_container.pull(filepath).read()
+        else:
+            on_disk = None
+
+        return on_disk != self._webserver_config_from_relation
+
+    def write_webserver_config(self, filepath: str, user: str, group: str) -> None:
+        """Render and write webserver_config.py in the workload container."""
+        self._workload_container.push(
+            filepath, self._webserver_config_from_relation, user=user, group=group, make_dirs=True
+        )
+
+    @property
     def can_write_tls_ca_chain(self) -> bool:
         """Indicate if there exist tls ca chains to write to workload container.
 
@@ -1185,6 +1241,7 @@ class AirflowCoordinatorProvides(ops.Object):
         self,
         config_template: typing.Optional[str] = None,
         k8s_executor_pod_spec_template: typing.Optional[str] = None,
+        webserver_config_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
         tls_ca_chains: dict[str, str] = {},
     ) -> None:
@@ -1193,6 +1250,7 @@ class AirflowCoordinatorProvides(ops.Object):
         Args:
             config_template: Airflow config as a Jinja2 template string.
             k8s_executor_pod_spec_template: (optional) K8s executor pod spec template.
+            webserver_config_template: (optional) Webserver config template for FAB OAuth.
             sensitive_data: sensitive data to render config of k8s executor pod
                 spec jinja templates with.
             tls_ca_chains: mapping from filename to tls ca chain file contents
@@ -1200,6 +1258,7 @@ class AirflowCoordinatorProvides(ops.Object):
         self._provider_handler.update_content(
             config_template=config_template,
             kubernetes_executor_pod_spec=k8s_executor_pod_spec_template,
+            webserver_config_template=webserver_config_template,
             sensitive_data=sensitive_data,
             tls_ca_chains=tls_ca_chains,
         )


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
- Update the airflow-coordinator charm lib for the api-server charm
- Use methods in AirflowCoordinatorCoreRequires to properly reconcile the presence or absence of the webserver_config file in the relation data
- Implement scenario tests for added functionality

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
