### PR TITLE
Update publish job to pass required read permissions and remove unrequired secrets due to external actions in use

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,8 @@ jobs:
       base-ref: ${{ github.event.before }}
       marker: charmcraft.yaml
       search-root: charms
-    secrets: inherit
+    permissions:
+      pull-requests: read
 
   run-tests:
     name: Unit + integration tests


### PR DESCRIPTION
…## Description
<!-- Summary of the changes in this PR -->
The publish charms workflow is broken: https://github.com/canonical/airflow-core-operators/actions/runs/27162071263/workflow

The `get-modified-charms` job is not passing `permissions: read` to `get_modified_directories_by_marker` job in `workfows-team` repo. This PR adds this permissions

**More critically**: the job also has `secrets: inherit`, where no secrets are being utilized by the underlying referenced job To make things a bit worse, the underlying referenced job also uses a 3rd party action which get access to all of this repo's secret. This is something we should not allow. This PR also removes the secrets access

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
