### PR TITLE
Fix indentation of publish job workflow_dispatch trigger

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "track/*"
-    workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   get-modified-charms:


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Added `workflow_dispatch` to the publish.yaml file was over-indented. This PR corrects this

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
